### PR TITLE
refactor: parallel bwa mem

### DIFF
--- a/config/sbatch.yml
+++ b/config/sbatch.yml
@@ -21,10 +21,13 @@ assignment_fastq_split:
   mem: 10G
   queue: medium
 assignment_mapping:
-  time: "0-20:00"
-  threads: 30
-  mem: 20G
+  time: "0-02:00"
+  threads: 10
+  mem: 2G
   queue: medium
+assignment_collect:
+  time: "1-12:00"
+  threads: 30
 assignment_getBCs:
   time: "0-04:00"
   threads: 1
@@ -33,17 +36,17 @@ assignment_statistic_totalCounts:
   time: "0-01:00"
   threads: 1
   queue: medium
-  mem: 40G
+  mem: 60G
 assignment_statistic_assignedCounts:
   time: "0-01:00"
   threads: 1
   queue: medium
-  mem: 40G
+  mem: 10G
 assignment_statistic_assignment:
   time: "0-01:00"
   threads: 1
   queue: medium
-  mem: 40G
+  mem: 20G
 ##############
 ### COUNTS ###
 ##############

--- a/config/sbatch.yml
+++ b/config/sbatch.yml
@@ -23,11 +23,13 @@ assignment_fastq_split:
 assignment_mapping:
   time: "0-02:00"
   threads: 10
-  mem: 2G
+  mem: 10G
   queue: medium
 assignment_collect:
   time: "1-12:00"
   threads: 30
+  mem: 10G
+  queue: medium
 assignment_getBCs:
   time: "0-04:00"
   threads: 1

--- a/workflow/rules/assignment.smk
+++ b/workflow/rules/assignment.smk
@@ -165,6 +165,7 @@ rule assignment_mapping:
         )  | samtools sort -l 0 -@ {threads} > {output} 2> {log}
         """
 
+
 rule assignment_collect:
     """
     Collect mapped reads.

--- a/workflow/rules/assignment.smk
+++ b/workflow/rules/assignment.smk
@@ -78,7 +78,7 @@ rule assignment_merge:
         script_FastQ2doubleIndexBAM=getScript("count/FastQ2doubleIndexBAM.py"),
         script_MergeTrimReadsBAM=getScript("count/MergeTrimReadsBAM.py"),
     output:
-        bam=temp("results/assignment/{assignment}/bam/merged/merge_split{split}.bam"),
+        bam=temp("results/assignment/{assignment}/bam/merge_split{split}.bam"),
     params:
         bc_length=lambda wc: config["assignments"][wc.assignment]["bc_length"],
     log:
@@ -144,14 +144,14 @@ rule assignment_mapping:
     Map the reads to the reference and sort.
     """
     input:
-        bams="results/assignment/{assignment}/bam/merged/merge_split{split}.bam",
+        bams="results/assignment/{assignment}/bam/merge_split{split}.bam",
         reference="results/assignment/{assignment}/reference/reference.fa",
         bwa_index=expand(
             "results/assignment/{{assignment}}/reference/reference.fa.{ext}",
             ext=["fai", "dict"] + assignment_bwa_dicts,
         ),
     output:
-        bam=temp("results/assignment/{assignment}/bam/mapped/mapped_split{split}.bam"),
+        bam=temp("results/assignment/{assignment}/bam/mapped_split{split}.mapped.bam"),
     conda:
         "../envs/bwa_samtools_picard_htslib.yaml"
     threads: config["global"]["threads"]
@@ -171,13 +171,14 @@ rule assignment_collect:
     """
     input:
         bams=expand(
-            "results/assignment/{{assignment}}/bam/mapped/mapped_split{split}.bam",
+            "results/assignment/{{assignment}}/bam/mapped_split{split}.mapped.bam",
             split=range(0, getSplitNumber()),
         ),
     output:
         "results/assignment/{assignment}/aligned_merged_reads.bam",
     conda:
         "../envs/bwa_samtools_picard_htslib.yaml"
+    threads: config["global"]["threads"]
     log:
         temp("results/logs/assignment/collect.{assignment}.log"),
     shell:

--- a/workflow/rules/assignment.smk
+++ b/workflow/rules/assignment.smk
@@ -151,7 +151,7 @@ rule assignment_mapping:
             ext=["fai", "dict"] + assignment_bwa_dicts,
         ),
     output:
-        bam=temp("results/assignment/{assignment}/bam/mapped_split{split}.mapped.bam"),
+        bam=temp("results/assignment/{assignment}/bam/merged_split{split}.mapped.bam"),
     conda:
         "../envs/bwa_samtools_picard_htslib.yaml"
     threads: config["global"]["threads"]
@@ -172,7 +172,7 @@ rule assignment_collect:
     """
     input:
         bams=expand(
-            "results/assignment/{{assignment}}/bam/mapped_split{split}.mapped.bam",
+            "results/assignment/{{assignment}}/bam/merged_split{split}.mapped.bam",
             split=range(0, getSplitNumber()),
         ),
     output:


### PR DESCRIPTION
Would run `bwa mem` and `samtools sort` as multiple processes for as many files as were created by splitfastq. Then a new rule `collect` will run `samtools merge` on the output (this takes little memory, but multiple threads and ~1 day of runtime in my case). Worked on my SLURM.