### PR TITLE
fix: A bug fix of BIH logo not appearing in the report.

### DIFF
--- a/workflow/report/css_style_sheets/custom-stylesheet.css
+++ b/workflow/report/css_style_sheets/custom-stylesheet.css
@@ -1,0 +1,13 @@
+:root {
+  --brand-image: url("https://res.cloudinary.com/bioinformaticsguy/image/upload/v1706099661/Work/dv1p1iist0niqbqukglm.png");
+}
+
+#brand {
+  margin: auto;
+  height: 150px;
+  width: 300px;
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  background-image: var(--brand-image);
+}
+

--- a/workflow/report/workflow.rst
+++ b/workflow/report/workflow.rst
@@ -1,9 +1,3 @@
 This workflow is created by `Max Schubach <max.schubach@bihealth.de>`_, Berlin Institute of Health at Charité, `Computational Genome Biology <https://kircherlab.bihealth.org>`_
 
 This pipeline processes sequencing data from Massively Parallel Reporter Assays (MPRA) to create count tables for candidate sequences tested in the experiment.
-
-
-------------
-
-.. image:: workflow/report/images/bih_logo.png
-   :width: 200


### PR DESCRIPTION
Added the css style sheet and removed the image code in the workflow.rst file.

Report with logo can be created by the following command:

`snakemake -c 6 --use-conda --snakefile /path/to/Snakefile --configfile config.yml --report report.html --report-stylesheet /path/to//css_style_sheets/custom-stylesheet.css`