### PR TITLE
fix: Assoc basic config fix

### DIFF
--- a/resources/assoc_basic/config.yml
+++ b/resources/assoc_basic/config.yml
@@ -12,11 +12,11 @@ assignments:
     alignment_start:
       min: 1
       max: 3
-    R1:
+    FW:
       - data/SRR10800986_1.fastq.gz
-    R2:
+    BC:
       - data/SRR10800986_2.fastq.gz
-    R3:
+    REV:
       - data/SRR10800986_3.fastq.gz
     reference: data/design.fa
     configs:


### PR DESCRIPTION
Fixed the parameters in the config file for the assoc_basic workflow. before this fix the assoc_basic workflow was not running. The fix can be tested by running the default command mentioned in the documentation,  of snakemake. 