### PR TITLE
fix: memory resources for bbmap

### DIFF
--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -43,7 +43,7 @@ set-resources:
     slurm_partition: medium
   assignment_mapping_bbmap:
     runtime: 120
-    mem: 2G
+    mem: 10G
     slurm_partition: medium
   assignment_collect:
     runtime: 2160

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -43,7 +43,7 @@ set-resources:
     slurm_partition: medium
   assignment_mapping_bbmap:
     runtime: 120
-    mem: 10G
+    mem: 2G
     slurm_partition: medium
   assignment_collect:
     runtime: 2160

--- a/workflow/rules/assignment/mapping_bbmap.smk
+++ b/workflow/rules/assignment/mapping_bbmap.smk
@@ -24,6 +24,9 @@ rule assignment_mapping_bbmap:
     """
     conda:
         "../../envs/bbmap_samtools_htslib.yaml"
+    threads: 1
+    resources:
+        mem="2G",
     input:
         reads="results/assignment/{assignment}/fastq/merge_split{split}.join.fastq.gz",
         check="results/assignment/{assignment}/design_check.done",
@@ -39,7 +42,8 @@ rule assignment_mapping_bbmap:
         temp("results/logs/assignment/mapping.bbmap.{assignment}.{split}.log"),
     shell:
         """
-        bbmap.sh in={input.reads} ref={input.reference} nodisk -t={threads} out={output.bam} &> {log};
+        bbmap.sh -eoom -Xmx{resources.mem} -t={threads} \
+        in={input.reads} ref={input.reference} nodisk out={output.bam} &> {log};
         samtools sort -l 0 -@ {threads} {output.bam} > {output.sorted_bam} 2>> {log};
         """
 

--- a/workflow/rules/assignment/mapping_bbmap.smk
+++ b/workflow/rules/assignment/mapping_bbmap.smk
@@ -26,7 +26,7 @@ rule assignment_mapping_bbmap:
         "../../envs/bbmap_samtools_htslib.yaml"
     threads: 1
     resources:
-        mem="2G",
+        mem="4G",
     input:
         reads="results/assignment/{assignment}/fastq/merge_split{split}.join.fastq.gz",
         check="results/assignment/{assignment}/design_check.done",


### PR DESCRIPTION
No memory resources was specified. Will break when more memory is needed.

Further it seems to important to use capital M or G instead of lower case.

