### PR TITLE
fix: merge.label.py does not report pseudocounts in barcode file

### DIFF
--- a/workflow/scripts/count/merge_label.py
+++ b/workflow/scripts/count/merge_label.py
@@ -191,11 +191,6 @@ def cli(
         statistic["matched barcodes"] / statistic["barcodes dna/rna"]
     ) * 100.0
 
-    # add pseudocount if needed:
-    counts["dna_count"] = counts["dna_count"] + pseudocountDNA
-    counts["rna_count"] = counts["rna_count"] + pseudocountRNA
-
-
     # number of DNA and RNA counts
     total_dna_counts = sum(counts["dna_count"])
     total_rna_counts = sum(counts["rna_count"])
@@ -241,6 +236,15 @@ def cli(
 
     # remove Barcorde. Not needed anymore
     counts.drop(["barcode"], axis=1, inplace=True)
+
+    # pseudocount if needed
+    counts["dna_count"] = counts["dna_count"] + pseudocountDNA
+    counts["rna_count"] = counts["rna_count"] + pseudocountRNA
+
+    if pseudocountDNA != 0:
+        total_dna_counts = sum(counts["dna_count"])
+    if pseudocountRNA != 0:
+        total_rna_counts = sum(counts["rna_count"])
 
     # group by oligo name 
     grouped_label = counts.groupby("oligo_name").agg(


### PR DESCRIPTION
Before when one modality can be 0 (RNA or DNA can be 0). we use a pseudo count to generate ratios. These pseudocount was also written into the barcode file.

Now a 0 is written when the BC was observed in the other modality. And Empty string when both modalities are not observed.

(older files can be transferred by -1 on all cells (except those that are empty)