### PR TITLE
fix: removed hard-coded barcode length (20) in hybrid reads (assignment workflow)

### DIFF
--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -16,6 +16,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Read version from file
         id: read_version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: install micromamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: docs/environment.yml
           environment-name: sphinx
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Lint workflow
-        uses: snakemake/snakemake-github-action@v1
+        uses: snakemake/snakemake-github-action@v2
         with:
           directory: .
           snakefile: workflow/Snakefile

--- a/workflow/rules/assignment/hybridFWRead.smk
+++ b/workflow/rules/assignment/hybridFWRead.smk
@@ -29,7 +29,7 @@ rule assignment_hybridFWRead_get_reads_by_length:
         """
         zcat {input.fastq} | \
         awk '{{if (NR%4==2 || NR%4==0){{
-                print substr($0,1,20) > "{output.BC_tmp}"; print substr($0,{params.insert_start}) > "{output.FW_tmp}"
+                print substr($0,1,{params.bc_length}) > "{output.BC_tmp}"; print substr($0,{params.insert_start}) > "{output.FW_tmp}"
             }} else {{
                 print $0 > "{output.BC_tmp}"; print $0 > "{output.FW_tmp}"
             }}}}';

--- a/workflow/scripts/quality_metrics.py
+++ b/workflow/scripts/quality_metrics.py
@@ -62,22 +62,22 @@ def experiment(barcode_file, assignment_file, bc_threshold, output_file):
     mpra_oligo_data = MPRABarcodeData.from_file(barcode_file).oligo_data
 
     # median_barcodes_passing_filtering
-    output["median_barcodes_passing_filtering"] = median_barcodes_passing_filtering(mpra_oligo_data)
+    output["median_barcodes_passing_filtering"] = int(median_barcodes_passing_filtering(mpra_oligo_data))
 
     # median_rna_read_count
-    output["median_rna_read_count"] = median_rna_read_count(mpra_oligo_data)
+    output["median_rna_read_count"] = int(median_rna_read_count(mpra_oligo_data))
 
     # now with threshold
     mpra_oligo_data.barcode_threshold = bc_threshold
 
     # pearson_correlation
-    output["pearson_correlation"] = pearson_correlation(mpra_oligo_data).round(4)
+    output["pearson_correlation"] = float(pearson_correlation(mpra_oligo_data).round(4))
 
     # fraction_oligos_passing
     assignment_df = pd.read_csv(assignment_file, sep="\t", header=None)
     assignment_grouped = assignment_df.groupby(1).size()
     assigned_oligos = len(assignment_grouped)
-    output["fraction_oligos_passing"] = round(fraction_oligos_passing(mpra_oligo_data, assigned_oligos), 4)
+    output["fraction_oligos_passing"] = float(round(fraction_oligos_passing(mpra_oligo_data, assigned_oligos), 4))
 
     # output
     json_string = json.dumps(output, indent=4)


### PR DESCRIPTION
Uses now the length of the barcode in the config file