### PR TITLE
Fixed various small bugs in mapping_bbmap.smk, common.smk, attachBCToFastQ.py, quality_metrics.py

### DIFF
--- a/workflow/rules/assignment/mapping_bbmap.smk
+++ b/workflow/rules/assignment/mapping_bbmap.smk
@@ -42,7 +42,7 @@ rule assignment_mapping_bbmap:
         temp("results/logs/assignment/mapping.bbmap.{assignment}.{split}.log"),
     shell:
         """
-        bbmap.sh -eoom -Xmx{resources.mem} -t={threads} \
+        bbmap.sh -eoom -Xmx{resources.mem} -t={threads} nullifybrokenquality \
         in={input.reads} ref={input.reference} nodisk out={output.bam} &> {log};
         samtools sort -l 0 -@ {threads} {output.bam} > {output.sorted_bam} 2>> {log};
         """

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -55,7 +55,7 @@ def check_version(pattern, version, config_version):
             )
 
 
-if not config["skip_version_check"]:
+if not config.get("skip_version_check", False):
     check_version(pattern_development_version, version, config["version"])
     check_version(pattern_major_version, version, config["version"])
 

--- a/workflow/scripts/attachBCToFastQ.py
+++ b/workflow/scripts/attachBCToFastQ.py
@@ -30,7 +30,7 @@ def read_sequence_files(
             seq_bc = reverse_complement(seq_bc)
             qual_bc = str(qual_bc)[::-1]
         seqid = "%s XI:Z:%s,YI:Z:%s" % (seqid_read, seq_bc, qual_bc)
-        if len(seqid) > 255:
+        if len(seqid) >= 255:
             """255 character limit for QNAME exceeded, No BC"""
             seqid = "%s XI:Z:%s,YI:Z:%s" % (seqid_read, "N", "I")
 

--- a/workflow/scripts/quality_metrics.py
+++ b/workflow/scripts/quality_metrics.py
@@ -80,7 +80,9 @@ def experiment(barcode_file, assignment_file, bc_threshold, output_file):
     output["fraction_oligos_passing"] = round(fraction_oligos_passing(mpra_oligo_data, assigned_oligos), 4)
 
     # output
-    json_string = json.dumps(output, indent=4)
+    #json_string = json.dumps(output, indent=4)
+    json_string = json.dumps(output, indent=4, default=lambda o: o.item() if isinstance(o, np.generic) else str(o))
+
     click.echo(json_string)
 
     if output_file:


### PR DESCRIPTION
Hello,

While using the pipeline I ran into a few issues in different modules. I’ve made some changes to address them, and I think they could be helpful for other users as well. Here’s a summary of the updates:

`mapping_bbmap.smk`
Added `nullifybrokenquality` to handle cases where read sequences and quality strings are different lengths. This prevents the pipeline from stopping entirely.
In the future, this could be added as a user-configurable option (opt in/out).

`common.smk`
Fixed an issue where not specifying "skip_version_check" caused an error, even though it’s meant to be optional.

`attachBCToFastQ.smk`
Adjusted the condition to len(seqid) >= 255.
Previously it only checked > 255, which led to a bug: if seqid was exactly 255 characters, adding the “@” pushed it over the 255-character SAM limit, breaking downstream tools like samtools.

`quality_metrics.py`
Fixed a JSON serialization error that occurred when encountering float32 objects
```   raise TypeError(f'Object of type {o.__class__.__name__} '
                    f'is not JSON serializable')
TypeError: Object of type float32 is not JSON serializable```

Thank you for making this wonderful tool, and the substantial logging you implemented has made it very easy to debug.

Grace