### PR TITLE
fix: snakemake reverted default value handling

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,14 +1,17 @@
 ##########################
+#### Version ####
+##########################
+from packaging import version
+f = open(workflow.source_path("../version.txt"))
+__version__ = version.parse(f.read().strip())
+
+print(f"\033[95mRunning MPRAsnakeflow version {__version__.public}\033[0m")
+
+##########################
 #### containerization ####
 ##########################
 
-f = open(workflow.source_path("../version.txt"))
-version = f.read().strip()
-
-print(f"\033[95mRunning MPRAsnakeflow version {version}\033[0m")
-
-
-containerized: f"docker://visze/mprasnakeflow:{version}"
+containerized: f"docker://visze/mprasnakeflow:{__version__.base_version}"
 
 
 #################

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2,6 +2,7 @@
 #### Version ####
 ##########################
 from packaging import version
+
 f = open(workflow.source_path("../version.txt"))
 __version__ = version.parse(f.read().strip())
 
@@ -10,6 +11,7 @@ print(f"\033[95mRunning MPRAsnakeflow version {__version__.public}\033[0m")
 ##########################
 #### containerization ####
 ##########################
+
 
 containerized: f"docker://visze/mprasnakeflow:{__version__.base_version}"
 


### PR DESCRIPTION

Handling only default version settings from snakemake 9.5.1 to 9.14.7. Should be fixed in 9.14.8

See [Snakemake #3614](https://github.com/snakemake/snakemake/issues/3614)

- also improved handling checking config versions using python package `from packaging import version`
