### PR TITLE
feat(experiment): :rocket: FWD/REV(/UMI) reads can be splitted into n files before merging

### DIFF
--- a/docs/1_getting_started/config.rst
+++ b/docs/1_getting_started/config.rst
@@ -152,7 +152,7 @@ The experiment workflow is configured in the :code:`experiments` section. Each e
     Length of the barcode. This is used to extract the barcode from the index read. The barcode is extracted from the first :code:`bc_length` bases of the index read. When no reverse read is given and :code:`adapter` is not set teh exact length is used to extract the DNA BC from the FWD read.
 :umi_length:
     (Optional) Length of the UMI. This is used to extract the UMI from the index read. The UMI is extracted from the last :code:`umi_length` bases of the index read. Please provide if you use UMIs.
-:split_number :
+:split_number:
     (Optional) To parallelize merging forward and reverse reads, they can be split into into :code:`split_number` files. For example, setting it to 30 means that the reads are split into 30 files, and each file is trimmed (if set) and merged in parallel. This is only useful when using a cluster to speed up the slower merging step. When running the workflow on a single machine, the default value should be used. The default is set to :code:`1`. (For technical reasons, when multiple experiments are defined, all will be set to the maximum defined in the config.)
 :adapters:
     (Optional) List of adapter sequences or fixed length to trim reads before running the workflow. Can be configured for all read inputs (FWD, REV, UMI). See :ref:`Adapter trimming` for a detailed overview.

--- a/docs/1_getting_started/config.rst
+++ b/docs/1_getting_started/config.rst
@@ -152,6 +152,8 @@ The experiment workflow is configured in the :code:`experiments` section. Each e
     Length of the barcode. This is used to extract the barcode from the index read. The barcode is extracted from the first :code:`bc_length` bases of the index read. When no reverse read is given and :code:`adapter` is not set teh exact length is used to extract the DNA BC from the FWD read.
 :umi_length:
     (Optional) Length of the UMI. This is used to extract the UMI from the index read. The UMI is extracted from the last :code:`umi_length` bases of the index read. Please provide if you use UMIs.
+:split_number :
+    (Optional) To parallelize merging forward and reverse reads, they can be split into into :code:`split_number` files. For example, setting it to 30 means that the reads are split into 30 files, and each file is trimmed (if set) and merged in parallel. This is only useful when using a cluster to speed up the slower merging step. When running the workflow on a single machine, the default value should be used. The default is set to :code:`1`. (For technical reasons, when multiple experiments are defined, all will be set to the maximum defined in the config.)
 :adapters:
     (Optional) List of adapter sequences or fixed length to trim reads before running the workflow. Can be configured for all read inputs (FWD, REV, UMI). See :ref:`Adapter trimming` for a detailed overview.
 :data_folder:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -43,6 +43,7 @@ wildcard_constraints:
     replicate=r"[^/_\.]+",
     type=r"(DNA)|(RNA)",
     config=r"[^/\.]+",
+    split=r"[0-9]+",
 
 
 ##### localrules #####

--- a/workflow/rules/assignment.smk
+++ b/workflow/rules/assignment.smk
@@ -95,7 +95,7 @@ Runs only if the design file is correct.
                 "results/assignment/{{assignment}}/fastq/splits/{{read}}.split{split}.fastq.gz",
                 split=range(
                     0,
-                    getSplitNumber(),
+                    getAssignmentSplitNumber(),
                 ),
             ),
         ),
@@ -113,7 +113,7 @@ Runs only if the design file is correct.
                     read=wc.read,
                     split=range(
                         0,
-                        getSplitNumber(),
+                        getAssignmentSplitNumber(),
                     ),
                 )
             ]
@@ -232,7 +232,7 @@ Get the barcodes.
                 "results/assignment/{{assignment}}/BCs/barcodes.{mapper}.{split}.tsv",
                 split=range(
                     0,
-                    getSplitNumber(),
+                    getAssignmentSplitNumber(),
                 ),
                 mapper=config["assignments"][wc.assignment]["alignment_tool"]["tool"],
             )
@@ -244,7 +244,7 @@ Get the barcodes.
     conda:
         getCondaEnv("default.yaml")
     params:
-        batch_size=("--batch-size=%d" % getSplitNumber() if getSplitNumber() > 1 else ""),
+        batch_size=("--batch-size=%d" % getAssignmentSplitNumber() if getAssignmentSplitNumber() > 1 else ""),
     shell:
         """
         export LC_ALL=C # speed up sort

--- a/workflow/rules/assignment/mapping_bwa.smk
+++ b/workflow/rules/assignment/mapping_bwa.smk
@@ -1,9 +1,7 @@
 rule assignment_mapping_bwa_ref:
     """
-    Create mapping reference for BWA from design file.
-    """
-    conda:
-        getCondaEnv("bwa_samtools_picard_htslib.yaml")
+Create mapping reference for BWA from design file.
+"""
     input:
         ref="results/assignment/{assignment}/reference/reference.fa",
         check="results/assignment/{assignment}/design_check.done",
@@ -15,6 +13,8 @@ rule assignment_mapping_bwa_ref:
         d="results/assignment/{assignment}/reference/reference.fa.dict",
     log:
         temp("results/logs/assignment/mapping.bwa_ref.{assignment}.log"),
+    conda:
+        getCondaEnv("bwa_samtools_picard_htslib.yaml")
     shell:
         """
         bwa index -a bwtsw {input.ref} &> {log};
@@ -25,11 +25,8 @@ rule assignment_mapping_bwa_ref:
 
 rule assignment_mapping_bwa:
     """
-    Map the reads to the reference and sort unsing bwa mem
-    """
-    conda:
-        getCondaEnv("bwa_samtools_picard_htslib.yaml")
-    threads: 1
+Map the reads to the reference and sort unsing bwa mem
+"""
     input:
         reads=lambda wc: getMappingRead(wc.assignment),
         reference="results/assignment/{assignment}/reference/reference.fa",
@@ -39,20 +36,19 @@ rule assignment_mapping_bwa:
         ),
     output:
         bam=temp("results/assignment/{assignment}/bwa/merge_split{split}.mapped.bam"),
+    log:
+        temp("results/logs/assignment/mapping.bwa.{assignment}.{split}.log"),
+    conda:
+        getCondaEnv("bwa_samtools_picard_htslib.yaml")
+    threads: 1
     params:
-        M=lambda wc: (
-            "-M"
-            if config["assignments"][wc.assignment]["alignment_tool"]["configs"]["M"]
-            else ""
-        ),
+        M=lambda wc: ("-M" if config["assignments"][wc.assignment]["alignment_tool"]["configs"]["M"] else ""),
         L=lambda wc: ",".join(
             map(
                 str,
                 config["assignments"][wc.assignment]["alignment_tool"]["configs"]["L"],
             )
         ),
-    log:
-        temp("results/logs/assignment/mapping.bwa.{assignment}.{split}.log"),
     shell:
         """
         bwa mem -t {threads} -L {params.L} {params.M} -C {input.reference} <(
@@ -63,32 +59,30 @@ rule assignment_mapping_bwa:
 
 rule assignment_mapping_bwa_getBCs:
     """
-    Get the barcodes.
-    """
-    conda:
-        getCondaEnv("bwa_samtools_picard_htslib.yaml")
+Get the barcodes.
+"""
     input:
         "results/assignment/{assignment}/bwa/merge_split{split}.mapped.bam",
     output:
         temp("results/assignment/{assignment}/BCs/barcodes.bwa.{split}.tsv"),
-    params:
-        alignment_start_min=lambda wc: config["assignments"][wc.assignment][
-            "alignment_tool"
-        ]["configs"]["alignment_start"]["min"],
-        alignment_start_max=lambda wc: config["assignments"][wc.assignment][
-            "alignment_tool"
-        ]["configs"]["alignment_start"]["max"],
-        sequence_length_min=lambda wc: config["assignments"][wc.assignment][
-            "alignment_tool"
-        ]["configs"]["sequence_length"]["min"],
-        sequence_length_max=lambda wc: config["assignments"][wc.assignment][
-            "alignment_tool"
-        ]["configs"]["sequence_length"]["max"],
-        mapping_quality_min=lambda wc: config["assignments"][wc.assignment][
-            "alignment_tool"
-        ]["configs"]["min_mapping_quality"],
     log:
         temp("results/logs/assignment/mapping.bwa.getBCs.{assignment}.{split}.log"),
+    conda:
+        getCondaEnv("bwa_samtools_picard_htslib.yaml")
+    params:
+        alignment_start_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["alignment_start"][
+            "min"
+        ],
+        alignment_start_max=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["alignment_start"][
+            "max"
+        ],
+        sequence_length_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["sequence_length"][
+            "min"
+        ],
+        sequence_length_max=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["sequence_length"][
+            "max"
+        ],
+        mapping_quality_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["min_mapping_quality"],
     shell:
         """
         export LC_ALL=C # speed up sorting
@@ -109,33 +103,27 @@ rule assignment_mapping_bwa_getBCs:
 
 rule assignment_mapping_bwa_getBCs_additional_filter:
     """
-    Get the barcodes with a python script to rescue alignments with 0 mapping quality according to bwa.
-    """
+Get the barcodes with a python script to rescue alignments with 0 mapping quality according to bwa.
+"""
     input:
         bam="results/assignment/{assignment}/bwa/merge_split{split}.mapped.bam",
         script=getScript("assignment/filter_bc_from_bam.py"),
     output:
         "results/assignment/{assignment}/BCs/barcodes.bwa-additional-filtering.{split}.tsv",
-    params:
-        identity_threshold=lambda wc: config["assignments"][wc.assignment][
-            "alignment_tool"
-        ]["configs"]["identity_threshold"],
-        mismatches_threshold=lambda wc: config["assignments"][wc.assignment][
-            "alignment_tool"
-        ]["configs"]["mismatches_threshold"],
-        expected_alignment_length=lambda wc: config["assignments"][wc.assignment][
-            "alignment_tool"
-        ]["configs"]["sequence_length"]["min"],
-        verbose=lambda wc: config["assignments"][wc.assignment]["alignment_tool"][
-            "configs"
-        ]["verbose"],
-        min_mapping_quality=lambda wc: config["assignments"][wc.assignment][
-            "alignment_tool"
-        ]["configs"]["min_mapping_quality"],
-    conda:
-        getCondaEnv("python3.yaml")
     log:
         "results/logs/assignment/mapping.bwa.getBCs_additional_filter.{assignment}.{split}.log",
+    conda:
+        getCondaEnv("python3.yaml")
+    params:
+        identity_threshold=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["identity_threshold"],
+        mismatches_threshold=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"][
+            "mismatches_threshold"
+        ],
+        expected_alignment_length=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"][
+            "sequence_length"
+        ]["min"],
+        verbose=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["verbose"],
+        min_mapping_quality=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["min_mapping_quality"],
     shell:
         """
         python {input.script} \
@@ -147,21 +135,21 @@ rule assignment_mapping_bwa_getBCs_additional_filter:
 
 rule assignment_collect:
     """
-    Collect mapped reads.
-    """
-    conda:
-        getCondaEnv("bwa_samtools_picard_htslib.yaml")
-    threads: 1
+Collect mapped reads.
+"""
     input:
         bams=lambda wc: expand(
             "results/assignment/{{assignment}}/{mapper}/merge_split{split}.mapped.bam",
-            split=range(0, getSplitNumber()),
+            split=range(0, getAssignmentSplitNumber()),
             mapper=config["assignments"][wc.assignment]["alignment_tool"]["tool"],
         ),
     output:
         "results/assignment/{assignment}/aligned_merged_reads.bam",
     log:
         temp("results/logs/assignment/collect.{assignment}.log"),
+    conda:
+        getCondaEnv("bwa_samtools_picard_htslib.yaml")
+    threads: 1
     shell:
         """
         samtools merge -@ {threads} {output} {input.bams} 2> {log}
@@ -170,16 +158,16 @@ rule assignment_collect:
 
 rule assignment_idx_bam:
     """
-    Index the BAM file
-    """
-    conda:
-        getCondaEnv("bwa_samtools_picard_htslib.yaml")
+Index the BAM file
+"""
     input:
         "results/assignment/{assignment}/aligned_merged_reads.bam",
     output:
         "results/assignment/{assignment}/aligned_merged_reads.bam.bai",
     log:
         "results/logs/assignment/{assignment}/assignment_idx_bam.log",
+    conda:
+        getCondaEnv("bwa_samtools_picard_htslib.yaml")
     shell:
         """
         samtools index {input} 2> {log}
@@ -188,10 +176,8 @@ rule assignment_idx_bam:
 
 rule assignment_flagstat:
     """
-    Run samtools flagstat
-    """
-    conda:
-        getCondaEnv("bwa_samtools_picard_htslib.yaml")
+Run samtools flagstat
+"""
     input:
         bam="results/assignment/{assignment}/aligned_merged_reads.bam",
         idx="results/assignment/{assignment}/aligned_merged_reads.bam.bai",
@@ -199,6 +185,8 @@ rule assignment_flagstat:
         "results/assignment/{assignment}/statistic/assignment/bam_stats.txt",
     log:
         temp("results/logs/assignment/flagstat.{assignment}.log"),
+    conda:
+        getCondaEnv("bwa_samtools_picard_htslib.yaml")
     shell:
         """
         samtools flagstat {input.bam} > {output} 2> {log}

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -23,9 +23,9 @@ from snakemake.utils import validate
 import pandas as pd
 
 # Workaround: validate() is broken from Snakemake 9.5.1 to snakemake 9.14.7 in remote jobs
-if version.parse(snakemake.__version__) >= version.parse("9.5.1") and version.parse(
-    snakemake.__version__
-) <= version.parse("9.14.7"):
+if version.parse(snakemake.__version__) >= version.parse("9.5.1") and version.parse(snakemake.__version__) <= version.parse(
+    "9.14.7"
+):
     from snakemake_interface_executor_plugins.settings import ExecMode
 
     # Use the global 'workflow' variable directly as recommended by Snakemake
@@ -77,26 +77,14 @@ def modify_config(config):
     if "assignments" in config:
         for assignment in config["assignments"].keys():
             if config["assignments"][assignment]["strand_sensitive"]["enable"]:
-                add_length = len(
-                    config["assignments"][assignment]["strand_sensitive"][
-                        "forward_adapter"
-                    ]
-                ) + len(
-                    config["assignments"][assignment]["strand_sensitive"][
-                        "reverse_adapter"
-                    ]
+                add_length = len(config["assignments"][assignment]["strand_sensitive"]["forward_adapter"]) + len(
+                    config["assignments"][assignment]["strand_sensitive"]["reverse_adapter"]
                 )
                 if config["assignments"][assignment]["alignment_tool"]["tool"] == "bwa":
-                    config["assignments"][assignment]["alignment_tool"]["configs"][
-                        "sequence_length"
-                    ]["min"] += add_length
-                    config["assignments"][assignment]["alignment_tool"]["configs"][
-                        "sequence_length"
-                    ]["max"] += add_length
+                    config["assignments"][assignment]["alignment_tool"]["configs"]["sequence_length"]["min"] += add_length
+                    config["assignments"][assignment]["alignment_tool"]["configs"]["sequence_length"]["max"] += add_length
                 else:
-                    config["assignments"][assignment]["alignment_tool"]["configs"][
-                        "sequence_length"
-                    ] += add_length
+                    config["assignments"][assignment]["alignment_tool"]["configs"]["sequence_length"] += add_length
     return config
 
 
@@ -168,10 +156,7 @@ def getAssignments(match_methods=None):
         if match_methods:
             output = []
             for assignment in config["assignments"]:
-                if (
-                    config["assignments"][assignment]["alignment_tool"]["tool"]
-                    in match_methods
-                ):
+                if config["assignments"][assignment]["alignment_tool"]["tool"] in match_methods:
                     output.append(assignment)
             return output
         else:
@@ -197,10 +182,7 @@ def getConditions(project):
 
 
 def getProjectAssignments(project):
-    if (
-        "assignments" in config["experiments"][project]
-        and len(config["experiments"][project]["assignments"]) > 0
-    ):
+    if "assignments" in config["experiments"][project] and len(config["experiments"][project]["assignments"]) > 0:
         return list(config["experiments"][project]["assignments"].keys())
     else:
         raise MissingAssignmentInConfigException(project)
@@ -431,9 +413,7 @@ def getOutputProjectConditionAssignmentConfigThreshold_helper(files):
             conditions = getConditions(project)
             for condition in conditions:
                 for conf in getConfigs(project):
-                    threshold = config["experiments"][project]["configs"][conf][
-                        "filter"
-                    ]["bc_threshold"]
+                    threshold = config["experiments"][project]["configs"][conf]["filter"]["bc_threshold"]
                     for file in files:
                         output += expand(
                             file,
@@ -507,9 +487,7 @@ def getOutputVariants_helper(files, betweenReplicates=False):
                             project=project,
                             condition=condition,
                             assignment=getProjectAssignments(project),
-                            config=list(
-                                config["experiments"][project]["configs"].keys()
-                            ),
+                            config=list(config["experiments"][project]["configs"].keys()),
                         )
     return output
 
@@ -546,8 +524,7 @@ def useSampling(project, conf, dna_or_rna):
 def withoutZeros(project, conf):
     return (
         config["experiments"][project]["configs"][conf]["filter"]["min_dna_counts"] > 0
-        and config["experiments"][project]["configs"][conf]["filter"]["min_rna_counts"]
-        > 0
+        and config["experiments"][project]["configs"][conf]["filter"]["min_rna_counts"] > 0
     )
 
 
@@ -559,7 +536,7 @@ def reverse_complement(seq):
     return "".join(reversed([complementary[i] for i in seq]))
 
 
-def getSplitNumber():
+def getAssignmentSplitNumber():
     splits = [1]
 
     for assignment in getAssignments():

--- a/workflow/rules/experiment/common.smk
+++ b/workflow/rules/experiment/common.smk
@@ -191,7 +191,9 @@ def getRawCounts(project: str, dnaRNA_type: str) -> str:
     """
     if useUMI(project, dnaRNA_type):
         if onlyFWD(project, dnaRNA_type):
-            return "results/experiments/{project}/counts/onlyFWDUMI.{condition}.{replicate}.%s.raw_counts.tsv.gz" % dnaRNA_type,
+            return (
+                "results/experiments/{project}/counts/onlyFWDUMI.{condition}.{replicate}.%s.raw_counts.tsv.gz" % dnaRNA_type,
+            )
         else:
             return "results/experiments/{project}/counts/useUMI.{condition}.{replicate}.%s.raw_counts.tsv.gz" % dnaRNA_type
     elif noUMI(project, dnaRNA_type):

--- a/workflow/rules/experiment/common.smk
+++ b/workflow/rules/experiment/common.smk
@@ -20,24 +20,33 @@ def getExperimentCutadaptAdapters(project, read):
     return " ".join(output)
 
 
+def getMaxExperimentSplitNumber() -> int:
+    splits = [1]
+
+    for project in getProjects():
+        splits += [config["experiments"][project]["split_number"]]
+
+    return max(splits)
+
+
 # count.smk specific functions
 
 
-def useUMI(project, type="DNA"):
+def useUMI(project: str, type: str = "DNA") -> bool:
     """
     Helper to check if UMI should be used
     """
     return "UMI" in experiments[project] or f"{type}_UMI" in experiments[project]
 
 
-def onlyFWD(project, type="DNA"):
+def onlyFWD(project: str, type: str = "DNA") -> bool:
     """
     Helper to check if only forward reads should be used
     """
     return f"{type}_BC_R" not in experiments[project]
 
 
-def noUMI(project, type="DNA"):
+def noUMI(project: str, type: str = "DNA") -> bool:
     """
     Helper to check if UMI should not be used
     """
@@ -48,45 +57,79 @@ def noUMI(project, type="DNA"):
     )
 
 
-def useTrimming(project, read_type):
+def useTrimming(project: str, read_type: str) -> bool:
+    """
+    Helper to check if trimming should be used for a specific read type.
+    """
     if "adapters" in config["experiments"][project]:
         if read_type in config["experiments"][project]["read_type"]:
             return True
     return False
 
 
-def getReads(read_type, project, condition, replicate, rnaDna_type, check_trimming=False):
+def useSplitting(project: str, rnaDna_type: str) -> bool:
+    """
+    Helper to check if splitting should be used. Will only apply for merging FWD and REV reads (creating BAM file) and split_number is > 1.
+    """
+    return not onlyFWD(project, rnaDna_type) and config["experiments"][project]["split_number"] > 1
+
+
+def getExperimentReads(
+    read_type: str,
+    project: str,
+    condition: str,
+    replicate: str,
+    rnaDna_type: str,
+    check_splitting: bool,
+    check_trimming: bool,
+):
     if read_type == "FWD":
-        return getFWD(project, condition, replicate, rnaDna_type, check_trimming)
+        return getFWD(project, condition, replicate, rnaDna_type, check_splitting, check_trimming)
     elif read_type == "REV":
-        return getREV(project, condition, replicate, rnaDna_type, check_trimming)
+        return getREV(project, condition, replicate, rnaDna_type, check_splitting, check_trimming)
     elif read_type == "UMI":
-        return getUMI(project, condition, replicate, rnaDna_type, check_trimming)
+        return getUMI(project, condition, replicate, rnaDna_type, check_splitting, check_trimming)
     else:
         raise ValueError("read_type must be one of FWD, REV or UMI")
 
 
-def getFWD(project, condition, replicate, rnaDna_type, check_trimming=False):
+def getFWD(
+    project: str, condition: str, replicate: str, rnaDna_type: str, check_splitting: bool, check_trimming: bool
+) -> list[str]:
     if check_trimming and useTrimming(project, "FWD"):
-        return "results/experiments/{project}/fastq/FWD.trimmed.{condition}.{replicate}.{type}.fastq.gz"
+        if check_splitting and useSplitting(project, rnaDna_type):
+            return ["results/experiments/{project}/fastq/FWD.trimmed.{condition}.{replicate}.{type}.{split}.fastq.gz"]
+        else:
+            return ["results/experiments/{project}/fastq/FWD.trimmed.{condition}.{replicate}.{type}.0.fastq.gz"]
 
-    exp = getExperiments(project)
-    exp = exp[exp.Condition == condition]
-    exp = exp[exp.Replicate.astype(str) == replicate]
-    return [
-        "%s/%s" % (config["experiments"][project]["data_folder"], f) for f in exp["%s_BC_F" % rnaDna_type].iloc[0].split(";")
-    ]
+    elif check_splitting and useSplitting(project, rnaDna_type):
+        return ["results/experiments/{project}/fastq/FWD.split.{condition}.{replicate}.{type}.{split}.fastq.gz"]
+    else:
+        exp = getExperiments(project)
+        exp = exp[exp.Condition == condition]
+        exp = exp[exp.Replicate.astype(str) == replicate]
+        return [
+            "%s/%s" % (config["experiments"][project]["data_folder"], f)
+            for f in exp["%s_BC_F" % rnaDna_type].iloc[0].split(";")
+        ]
 
 
-def getFWDWithIndex(project):
+def getFWDWithIndex(project: str) -> list[str]:
     return [
         "%s/%s" % (config["experiments"][project]["data_folder"], f) for f in getExperiments(project).BC_F.iloc[0].split(";")
     ]
 
 
-def getREV(project, condition, replicate, rnaDna_type, check_trimming=False):
+def getREV(
+    project: str, condition: str, replicate: str, rnaDna_type: str, check_splitting: bool, check_trimming: bool
+) -> list[str]:
     if check_trimming and useTrimming(project, "REV"):
-        return "results/experiments/{project}/fastq/REV.trimmed.{condition}.{replicate}.{type}.fastq.gz"
+        if check_splitting and useSplitting(project, rnaDna_type):
+            return ["results/experiments/{project}/fastq/REV.trimmed.{condition}.{replicate}.{type}.{split}.fastq.gz"]
+        else:
+            return ["results/experiments/{project}/fastq/REV.trimmed.{condition}.{replicate}.{type}.0.fastq.gz"]
+    elif check_splitting and useSplitting(project, rnaDna_type):
+        return ["results/experiments/{project}/fastq/REV.split.{condition}.{replicate}.{type}.{split}.fastq.gz"]
     else:
         exp = getExperiments(project)
         exp = exp[exp.Condition == condition]
@@ -97,15 +140,22 @@ def getREV(project, condition, replicate, rnaDna_type, check_trimming=False):
         ]
 
 
-def getREVWithIndex(project):
+def getREVWithIndex(project: str) -> list[str]:
     return [
         "%s%s" % (config["experiments"][project]["data_folder"], f) for f in getExperiments(project).BC_R.iloc[0].split(";")
     ]
 
 
-def getUMI(project, condition, replicate, rnaDna_type, check_trimming=False):
+def getUMI(
+    project: str, condition: str, replicate: str, rnaDna_type: str, check_splitting: bool, check_trimming: bool
+) -> list[str]:
     if check_trimming and useTrimming(project, "UMI"):
-        return "results/experiments/{project}/fastq/UMI.trimmed.{condition}.{replicate}.{type}.fastq.gz"
+        if check_splitting and useSplitting(project, rnaDna_type):
+            return ["results/experiments/{project}/fastq/UMI.trimmed.{condition}.{replicate}.{type}.{split}.fastq.gz"]
+        else:
+            return ["results/experiments/{project}/fastq/UMI.trimmed.{condition}.{replicate}.{type}.0.fastq.gz"]
+    elif check_splitting and useSplitting(project, rnaDna_type):
+        return ["results/experiments/{project}/fastq/UMI.split.{condition}.{replicate}.{type}.{split}.fastq.gz"]
     else:
         exp = getExperiments(project)
         exp = exp[exp.Condition == condition]
@@ -116,49 +166,40 @@ def getUMI(project, condition, replicate, rnaDna_type, check_trimming=False):
         ]
 
 
-def getUMIWithIndex(project):
+def getUMIWithIndex(project: str) -> list[str]:
     return [config["experiments"][project]["data_folder"] + f for f in getExperiments(project).UMI.iloc[0].split(";")]
 
 
-def getIndexWithIndex(project):
+def getIndexWithIndex(project: str) -> list[str]:
     return [config["experiments"][project]["data_folder"] + f for f in getExperiments(project).INDEX.iloc[0].split(";")]
 
 
-def getUMIBamFile(project, condition, replicate, type):
+def getUMIBamFile(project: str) -> str:
     """
-    gelper to get the correct BAM file (demultiplexed or not)
+    Helper to get the correct BAM file (demultiplexed or not)
     """
+
     if config["experiments"][project]["demultiplex"]:
-        return "results/%s/counts/merged_demultiplex.%s.%s.%s.bam" % (
-            project,
-            condition,
-            replicate,
-            type,
-        )
+        return "results/experiments/{project}/counts/merged_demultiplex.{condition}.{replicate}.{type}.bam"
     else:
-        return "results/experiments/%s/counts/useUMI.%s.%s.%s.bam" % (
-            project,
-            condition,
-            replicate,
-            type,
-        )
+        return "results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.{split}.bam"
 
 
-def getRawCounts(project, type):
+def getRawCounts(project: str, dnaRNA_type: str) -> str:
     """
     Helper to get the correct raw counts file (umi/noUMI or just FWD read)
     """
-    if useUMI(project, type):
-        if onlyFWD(project, type):
-            return "results/experiments/{project}/counts/onlyFWDUMI.{condition}.{replicate}.%s.raw_counts.tsv.gz" % type
+    if useUMI(project, dnaRNA_type):
+        if onlyFWD(project, dnaRNA_type):
+            return "results/experiments/{project}/counts/onlyFWDUMI.{condition}.{replicate}.%s.raw_counts.tsv.gz" % dnaRNA_type,
         else:
-            return "results/experiments/{project}/counts/useUMI.{condition}.{replicate}.%s.raw_counts.tsv.gz" % type
-    elif noUMI(project, type):
-        return "results/experiments/{project}/counts/noUMI.{condition}.{replicate}.%s.raw_counts.tsv.gz" % type
-    elif onlyFWD(project, type):
-        return "results/experiments/{project}/counts/onlyFWD.{condition}.{replicate}.%s.raw_counts.tsv.gz" % type
+            return "results/experiments/{project}/counts/useUMI.{condition}.{replicate}.%s.raw_counts.tsv.gz" % dnaRNA_type
+    elif noUMI(project, dnaRNA_type):
+        return "results/experiments/{project}/counts/noUMI.{condition}.{replicate}.%s.raw_counts.tsv.gz" % dnaRNA_type
+    elif onlyFWD(project, dnaRNA_type):
+        return "results/experiments/{project}/counts/onlyFWD.{condition}.{replicate}.%s.raw_counts.tsv.gz" % dnaRNA_type
     else:
-        raise RuntimeError("Error in getRawCounts: no valid option for %s and %s found" % (project, type))
+        raise RuntimeError("Error in getRawCounts: no valid option for %s and %s found" % (project, dnaRNA_type))
 
 
 def counts_aggregate_demultiplex_input(project):

--- a/workflow/rules/experiment/counts.smk
+++ b/workflow/rules/experiment/counts.smk
@@ -12,20 +12,18 @@ include: "counts/counts_onlyFWDWithUMI.smk"
 
 rule experiment_counts_filter_counts:
     """
-    Filter the counts to BCs only of the correct length (defined in the config file)
-    """
-    conda:
-        getCondaEnv("default.yaml")
+Filter the counts to BCs only of the correct length (defined in the config file)
+"""
     input:
         lambda wc: getRawCounts(wc.project, wc.type),
     output:
         "results/experiments/{project}/counts/{condition}.{replicate}.{type}.filtered_counts.tsv.gz",
+    log:
+        temp("results/logs/experiment/counts/filter_counts.{project}.{condition}.{replicate}.{type}.log"),
+    conda:
+        getCondaEnv("default.yaml")
     params:
         bc_length=lambda wc: config["experiments"][wc.project]["bc_length"],
-    log:
-        temp(
-            "results/logs/experiment/counts/filter_counts.{project}.{condition}.{replicate}.{type}.log"
-        ),
     shell:
         """
         bc={params.bc_length};
@@ -39,19 +37,17 @@ rule experiment_counts_filter_counts:
 
 rule experiment_counts_final_counts:
     """
-    Counting BCs.
-    Discarding PCR duplicates (taking BCxUMI only one time)
-    """
-    conda:
-        getCondaEnv("default.yaml")
+Counting BCs.
+Discarding PCR duplicates (taking BCxUMI only one time)
+"""
     input:
         "results/experiments/{project}/counts/{condition}.{replicate}.{type}.filtered_counts.tsv.gz",
     output:
         counts="results/experiments/{project}/counts/{condition}.{replicate}.{type}.final_counts.tsv.gz",
     log:
-        temp(
-            "results/logs/experiment/counts/final_counts_umi.{project}.{condition}.{replicate}.{type}.log"
-        ),
+        temp("results/logs/experiment/counts/final_counts_umi.{project}.{condition}.{replicate}.{type}.log"),
+    conda:
+        getCondaEnv("default.yaml")
     shell:
         """
         zcat {input} | awk '{{print $1}}' | \
@@ -63,33 +59,23 @@ rule experiment_counts_final_counts:
 
 rule experiment_counts_final_counts_sampler:
     """
-    Creates full + new distribution DNA files
-    """
-    conda:
-        getCondaEnv("python3.yaml")
+Creates full + new distribution DNA files
+"""
     input:
         counts="results/experiments/{project}/counts/{condition}.{replicate}.{type}.final_counts.tsv.gz",
         script=getScript("count/samplerer.py"),
     output:
         "results/experiments/{project}/counts/{condition}.{replicate}.{type}.final_counts.sampling.{config}.tsv.gz",
-    params:
-        samplingprop=lambda wc: counts_getSamplingConfig(
-            wc.project, wc.config, wc.type, "prop"
-        ),
-        downsampling=lambda wc: counts_getSamplingConfig(
-            wc.project, wc.config, wc.type, "threshold"
-        ),
-        samplingtotal=lambda wc: counts_getSamplingConfig(
-            wc.project, wc.config, wc.type, "total"
-        ),
-        seed=lambda wc: counts_getSamplingConfig(wc.project, wc.config, wc.type, "seed"),
-        filtermincounts=lambda wc: counts_getFilterConfig(
-            wc.project, wc.config, wc.type, "min_counts"
-        ),
     log:
-        temp(
-            "results/logs/experiment/counts/final_counts_umi_samplerer.{project}.{condition}.{replicate}.{type}.{config}.log"
-        ),
+        temp("results/logs/experiment/counts/final_counts_umi_samplerer.{project}.{condition}.{replicate}.{type}.{config}.log"),
+    conda:
+        getCondaEnv("python3.yaml")
+    params:
+        samplingprop=lambda wc: counts_getSamplingConfig(wc.project, wc.config, wc.type, "prop"),
+        downsampling=lambda wc: counts_getSamplingConfig(wc.project, wc.config, wc.type, "threshold"),
+        samplingtotal=lambda wc: counts_getSamplingConfig(wc.project, wc.config, wc.type, "total"),
+        seed=lambda wc: counts_getSamplingConfig(wc.project, wc.config, wc.type, "seed"),
+        filtermincounts=lambda wc: counts_getFilterConfig(wc.project, wc.config, wc.type, "min_counts"),
     shell:
         """
         python {input.script} --input {input.counts} \
@@ -104,33 +90,25 @@ rule experiment_counts_final_counts_sampler:
 
 rule experiment_counts_dna_rna_merge_counts:
     """
-    Merge DNA and RNA counts together.
-    Is done in two ways. First no not allow zeros in DNA or RNA BCs (RNA and DNA min_counts not zero).
-    Second with zeros, so a BC can be defined only in the DNA or RNA (RNA or DNA min_counts zero)
-    """
-    conda:
-        getCondaEnv("default.yaml")
+Merge DNA and RNA counts together.
+Is done in two ways. First no not allow zeros in DNA or RNA BCs (RNA and DNA min_counts not zero).
+Second with zeros, so a BC can be defined only in the DNA or RNA (RNA or DNA min_counts zero)
+"""
     input:
-        dna=lambda wc: getFinalCounts(
-            wc.project, wc.config, wc.condition, "DNA", wc.raw_or_assigned
-        ),
-        rna=lambda wc: getFinalCounts(
-            wc.project, wc.config, wc.condition, "RNA", wc.raw_or_assigned
-        ),
+        dna=lambda wc: getFinalCounts(wc.project, wc.config, wc.condition, "DNA", wc.raw_or_assigned),
+        rna=lambda wc: getFinalCounts(wc.project, wc.config, wc.condition, "RNA", wc.raw_or_assigned),
     output:
         "results/experiments/{project}/{raw_or_assigned}/{condition}.{replicate}.merged.config.{config}.tsv.gz",
-    params:
-        zero=lambda wc: "false" if withoutZeros(wc.project, wc.config) else "true",
-        minRNACounts=lambda wc: counts_getFilterConfig(
-            wc.project, wc.config, "RNA", "min_counts"
-        ),
-        minDNACounts=lambda wc: counts_getFilterConfig(
-            wc.project, wc.config, "DNA", "min_counts"
-        ),
     log:
         temp(
             "results/logs/experiment/counts/dna_rna_merge_counts.{project}.{raw_or_assigned}.{condition}.{replicate}.{config}.log"
         ),
+    conda:
+        getCondaEnv("default.yaml")
+    params:
+        zero=lambda wc: "false" if withoutZeros(wc.project, wc.config) else "true",
+        minRNACounts=lambda wc: counts_getFilterConfig(wc.project, wc.config, "RNA", "min_counts"),
+        minDNACounts=lambda wc: counts_getFilterConfig(wc.project, wc.config, "DNA", "min_counts"),
     shell:
         """
         zero={params.zero};

--- a/workflow/rules/experiment/counts/counts_demultiplex.smk
+++ b/workflow/rules/experiment/counts/counts_demultiplex.smk
@@ -7,10 +7,8 @@
 
 rule experiment_counts_demultiplex_create_index:
     """
-    Create the demultiplexing index file for the experiment.
-    """
-    conda:
-        getCondaEnv("python3.yaml")
+Create the demultiplexing index file for the experiment.
+"""
     input:
         experiment_file=lambda wc: config["experiments"][wc.project]["experiment_file"],
         script=getScript("count/create_demultiplexed_index.py"),
@@ -18,6 +16,8 @@ rule experiment_counts_demultiplex_create_index:
         "results/experiments/{project}/counts/demultiplex_index.tsv",
     log:
         temp("results/logs/experiment/counts/create_demultiplexed_index.{project}.log"),
+    conda:
+        getCondaEnv("python3.yaml")
     shell:
         """
         python {input.script} \
@@ -28,8 +28,8 @@ rule experiment_counts_demultiplex_create_index:
 
 checkpoint experiment_counts_demultiplex_BAM_umi:
     """
-    Demultiplexing the data and create demultiplexed bam files per condition.
-    """
+Demultiplexing the data and create demultiplexed bam files per condition.
+"""
     input:
         fwd_fastq=lambda wc: getFWDWithIndex(wc.project),
         rev_fastq=lambda wc: getREVWithIndex(wc.project),
@@ -39,12 +39,12 @@ checkpoint experiment_counts_demultiplex_BAM_umi:
         script=getScript("count/SplitFastQdoubleIndexBAM.py"),
     output:
         "results/experiments/{project}/counts/demultiplex.{name}.bam",
-    params:
-        outdir=lambda w, output: os.path.split(output[0])[0],
-    conda:
-        getCondaEnv("python27.yaml")
     log:
         temp("results/logs/experiment/counts/demultiplex_BAM_umi.{project}.{name}.log"),
+    conda:
+        getCondaEnv("python27.yaml")
+    params:
+        outdir=lambda w, output: os.path.split(output[0])[0],
     shell:
         """
             set +o pipefail;
@@ -74,8 +74,8 @@ checkpoint experiment_counts_demultiplex_BAM_umi:
 
 rule experiment_counts_demultiplex_aggregate:
     """
-    Aggregate the demultiplexed bam files per condition.
-    """
+Aggregate the demultiplexed bam files per condition.
+"""
     input:
         lambda wc: counts_aggregate_demultiplex_input(wc.project),
     output:
@@ -84,21 +84,19 @@ rule experiment_counts_demultiplex_aggregate:
 
 rule experiment_counts_demultiplex_mergeTrimReads_BAM_umi:
     """
-    Merge and trim reads in demultiplexed bam files.
-    """
+Merge and trim reads in demultiplexed bam files.
+"""
     input:
         demultiplex="results/experiments/{project}/counts/demultiplex.done",
         script=getScript("count/MergeTrimReadsBAM.py"),
     output:
         "results/experiments/{project}/counts/merged_demultiplex.{condition}.{replicate}.{type}.bam",
+    log:
+        temp("results/logs/experiment/counts/mergeTrimReads_demultiplex_BAM_umi.{project}.{condition}.{replicate}.{type}.log"),
     conda:
         getCondaEnv("python27.yaml")
     params:
         bam="results/experiments/{project}/counts/demultiplex.{condition}.{replicate}.{type}.bam",
-    log:
-        temp(
-            "results/logs/experiment/counts/mergeTrimReads_demultiplex_BAM_umi.{project}.{condition}.{replicate}.{type}.log"
-        ),
     shell:
         """
         samtools view -h {params.bam} | \

--- a/workflow/rules/experiment/counts/counts_noUMI.smk
+++ b/workflow/rules/experiment/counts/counts_noUMI.smk
@@ -8,30 +8,24 @@
 
 rule experiment_counts_noUMI_create_BAM:
     """
-    Create a BAM file from FASTQ input, merge FWD and REV read and save UMI in XI flag.
-    """
+Create a BAM file from FASTQ input, merge FWD and REV read and save UMI in XI flag.
+"""
     input:
-        fwd_fastq=lambda wc: getFWD(
-            wc.project, wc.condition, wc.replicate, wc.type, check_trimming=True
-        ),
-        rev_fastq=lambda wc: getREV(
-            wc.project, wc.condition, wc.replicate, wc.type, check_trimming=True
-        ),
+        fwd_fastq=lambda wc: getFWD(wc.project, wc.condition, wc.replicate, wc.type, check_splitting=True, check_trimming=True),
+        rev_fastq=lambda wc: getREV(wc.project, wc.condition, wc.replicate, wc.type, check_splitting=True, check_trimming=True),
         script_FastQ2doubleIndexBAM=getScript("count/FastQ2doubleIndexBAM_python3.py"),
         module_FastQ2doubleIndexBAM=getScript("count/library_python3.py"),
         script_MergeTrimReadsBAM=getScript("count/MergeTrimReadsBAM_python3.py"),
         module_MergeTrimReadsBAM=getScript("count/MergeTrimReads_python3.py"),
     output:
-        "results/experiments/{project}/counts/noUMI.{condition}.{replicate}.{type}.bam",
+        "results/experiments/{project}/counts/noUMI.{condition}.{replicate}.{type}.{split}.bam",
+    log:
+        temp("results/logs/experiment/counts/noUMI/create_BAM.{project}.{condition}.{replicate}.{type}.{split}.log"),
+    conda:
+        getCondaEnv("python3.yaml")
     params:
         bc_length=lambda wc: config["experiments"][wc.project]["bc_length"],
         datasetID="{condition}.{replicate}.{type}",
-    conda:
-        getCondaEnv("python3.yaml")
-    log:
-        temp(
-            "results/logs/experiment/counts/noUMI/create_BAM.{project}.{condition}.{replicate}.{type}.log"
-        ),
     shell:
         """
         set +o pipefail;
@@ -59,23 +53,24 @@ rule experiment_counts_noUMI_create_BAM:
 
 rule experiment_counts_noUMI_raw_counts:
     """
-    Counting BCsxUMIs from the BAM files.
-    """
-    conda:
-        getCondaEnv("bwa_samtools_picard_htslib.yaml")
+Counting BCsxUMIs from the BAM files.
+"""
     input:
-        "results/experiments/{project}/counts/noUMI.{condition}.{replicate}.{type}.bam",
+        expand(
+            "results/experiments/{{project}}/counts/noUMI.{{condition}}.{{replicate}}.{{type}}.{split}.bam",
+            split=range(getMaxExperimentSplitNumber()),
+        ),
     output:
         "results/experiments/{project}/counts/noUMI.{condition}.{replicate}.{type}.raw_counts.tsv.gz",
+    log:
+        temp("results/logs/experiment/counts/noUMI/raw_counts_umi.{project}.{condition}.{replicate}.{type}.log"),
+    conda:
+        getCondaEnv("bwa_samtools_picard_htslib.yaml")
     params:
         datasetID="{condition}.{replicate}.{type}",
-    log:
-        temp(
-            "results/logs/experiment/counts/noUMI/raw_counts_umi.{project}.{condition}.{replicate}.{type}.log"
-        ),
     shell:
         """
-        samtools view -F 1 -r {params.datasetID} {input} | \
+        samtools merge -o - {input} | samtools view -F 1 -r {params.datasetID} | \
         awk -v 'OFS=\\t' '{{ print $10 }}' | \
         sort | \
         gzip -c > {output} 2> {log}

--- a/workflow/rules/experiment/counts/counts_noUMI.smk
+++ b/workflow/rules/experiment/counts/counts_noUMI.smk
@@ -70,7 +70,7 @@ Counting BCsxUMIs from the BAM files.
         datasetID="{condition}.{replicate}.{type}",
     shell:
         """
-        samtools merge -o - {input} | samtools view -F 1 -r {params.datasetID} | \
+        samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
         awk -v 'OFS=\\t' '{{ print $10 }}' | \
         sort | \
         gzip -c > {output} 2> {log}

--- a/workflow/rules/experiment/counts/counts_onlyFWD.smk
+++ b/workflow/rules/experiment/counts/counts_onlyFWD.smk
@@ -7,25 +7,19 @@
 
 rule experiment_counts_onlyFWD_raw_counts:
     """
-    Getting the BCs from the reads using fixed length.
-    """
-    conda:
-        getCondaEnv("default.yaml")
+Getting the BCs from the reads using fixed length.
+"""
     input:
-        lambda wc: getFWD(
-            wc.project, wc.condition, wc.replicate, wc.type, check_trimming=True
-        ),
+        lambda wc: getFWD(wc.project, wc.condition, wc.replicate, wc.type, check_splitting=False, check_trimming=True),
     output:
         "results/experiments/{project}/counts/onlyFWD.{condition}.{replicate}.{type}.raw_counts.tsv.gz",
+    log:
+        temp("results/logs/experiment/counts/onlyFWD/onlyFWD_raw_counts.{project}.{condition}.{replicate}.{type}.log"),
+    conda:
+        getCondaEnv("default.yaml")
     params:
         bc_length=lambda wc: config["experiments"][wc.project]["bc_length"],
-        bc_extraction=lambda wc: config["experiments"][wc.project].get(
-            "bc_extraction", "start"
-        ),
-    log:
-        temp(
-            "results/logs/experiment/counts/onlyFWD/onlyFWD_raw_counts.{project}.{condition}.{replicate}.{type}.log"
-        ),
+        bc_extraction=lambda wc: config["experiments"][wc.project].get("bc_extraction", "start"),
     shell:
         """
         zcat {input} | \

--- a/workflow/rules/experiment/counts/counts_onlyFWDWithUMI.smk
+++ b/workflow/rules/experiment/counts/counts_onlyFWDWithUMI.smk
@@ -8,32 +8,28 @@
 
 rule experiment_counts_onlyFWDUMI_raw_counts:
     """
-    Getting the BCs and UMIs from the reads using fixed length.
-    """
-    conda:
-        getCondaEnv("default.yaml")
+Getting the BCs and UMIs from the reads using fixed length.
+"""
     input:
         fwd_fastq=lambda wc: getFWD(
-            wc.project, wc.condition, wc.replicate, wc.type, check_trimming=True
+            wc.project, wc.condition, wc.replicate, wc.type, check_splitting=False, check_trimming=True
         ),
         umi_fastq=lambda wc: getUMI(
-            wc.project, wc.condition, wc.replicate, wc.type, check_trimming=True
+            wc.project, wc.condition, wc.replicate, wc.type, check_splitting=False, check_trimming=True
         ),
     output:
         "results/experiments/{project}/counts/onlyFWDUMI.{condition}.{replicate}.{type}.raw_counts.tsv.gz",
-    params:
-        bc_length=lambda wc: config["experiments"][wc.project]["bc_length"],
-        umi_length=lambda wc: config["experiments"][wc.project]["umi_length"],
-        bc_extraction=lambda wc: config["experiments"][wc.project].get(
-            "bc_extraction", "start"
-        ),
-        umi_extraction=lambda wc: config["experiments"][wc.project].get(
-            "umi_extraction", "start"
-        ),
     log:
         temp(
             "results/logs/experiment/counts/onlyFWD/onlyFWDUMI_raw_counts_by_length.{project}.{condition}.{replicate}.{type}.log"
         ),
+    conda:
+        getCondaEnv("default.yaml")
+    params:
+        bc_length=lambda wc: config["experiments"][wc.project]["bc_length"],
+        umi_length=lambda wc: config["experiments"][wc.project]["umi_length"],
+        bc_extraction=lambda wc: config["experiments"][wc.project].get("bc_extraction", "start"),
+        umi_extraction=lambda wc: config["experiments"][wc.project].get("umi_extraction", "start"),
     shell:
         """
         paste <(zcat {input.fwd_fastq} | awk 'NR%4==2 {{if ("{params.bc_extraction}" == "start") print substr($1,1,{params.bc_length}); else print substr($1,length($1)-{params.bc_length}+1)}}') \

--- a/workflow/rules/experiment/counts/counts_umi.smk
+++ b/workflow/rules/experiment/counts/counts_umi.smk
@@ -76,7 +76,7 @@ Counting BCsxUMIs from the BAM files.
         datasetID="{condition}.{replicate}.{type}",
     shell:
         """
-        samtools merge -o - {input} | samtools view -F 1 -r {params.datasetID} | \
+        samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
         awk -v 'OFS=\\t' '{{ for (i=12; i<=NF; i++) {{
           if ($i ~ /^XJ:Z:/) print $10,substr($i,6,{params.umi_length})
         }}}}' | \

--- a/workflow/rules/experiment/counts/counts_umi.smk
+++ b/workflow/rules/experiment/counts/counts_umi.smk
@@ -8,34 +8,26 @@
 
 rule experiment_counts_umi_create_BAM:
     """
-    Create a BAM file from FASTQ input, merge FWD and REV read and save UMI in XI flag.
-    """
+Create a BAM file from FASTQ input, merge FWD and REV read and save UMI in XI flag.
+"""
     input:
-        fwd_fastq=lambda wc: getFWD(
-            wc.project, wc.condition, wc.replicate, wc.type, check_trimming=True
-        ),
-        rev_fastq=lambda wc: getREV(
-            wc.project, wc.condition, wc.replicate, wc.type, check_trimming=True
-        ),
-        umi_fastq=lambda wc: getUMI(
-            wc.project, wc.condition, wc.replicate, wc.type, check_trimming=True
-        ),
+        fwd_fastq=lambda wc: getFWD(wc.project, wc.condition, wc.replicate, wc.type, check_splitting=True, check_trimming=True),
+        rev_fastq=lambda wc: getREV(wc.project, wc.condition, wc.replicate, wc.type, check_splitting=True, check_trimming=True),
+        umi_fastq=lambda wc: getUMI(wc.project, wc.condition, wc.replicate, wc.type, check_splitting=True, check_trimming=True),
         script_FastQ2doubleIndexBAM=getScript("count/FastQ2doubleIndexBAM_python3.py"),
         module_FastQ2doubleIndexBAM=getScript("count/library_python3.py"),
         script_MergeTrimReadsBAM=getScript("count/MergeTrimReadsBAM_python3.py"),
         module_MergeTrimReadsBAM=getScript("count/MergeTrimReads_python3.py"),
     output:
-        "results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.bam",
+        "results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.{split}.bam",
+    log:
+        temp("results/logs/experiment/counts/umi/create_BAM.{project}.{condition}.{replicate}.{type}.{split}.log"),
+    conda:
+        getCondaEnv("python3.yaml")
     params:
         bc_length=lambda wc: config["experiments"][wc.project]["bc_length"],
         umi_length=lambda wc: config["experiments"][wc.project]["umi_length"],
         datasetID="{condition}.{replicate}.{type}",
-    conda:
-        getCondaEnv("python3.yaml")
-    log:
-        temp(
-            "results/logs/experiment/counts/umi/create_BAM.{project}.{condition}.{replicate}.{type}.log"
-        ),
     shell:
         """
         set +o pipefail;
@@ -62,24 +54,29 @@ rule experiment_counts_umi_create_BAM:
 
 rule experiment_counts_umi_raw_counts:
     """
-    Counting BCsxUMIs from the BAM files.
-    """
-    conda:
-        getCondaEnv("bwa_samtools_picard_htslib.yaml")
+Counting BCsxUMIs from the BAM files.
+"""
     input:
-        lambda wc: getUMIBamFile(wc.project, wc.condition, wc.replicate, wc.type),
+        lambda wc: expand(
+            getUMIBamFile(wc.project),
+            project=wc.project,
+            condition=wc.condition,
+            replicate=wc.replicate,
+            type=wc.type,
+            split=range(getMaxExperimentSplitNumber()),
+        ),
     output:
         "results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.raw_counts.tsv.gz",
+    log:
+        temp("results/logs/experiment/counts/umi/raw_counts.{project}.{condition}.{replicate}.{type}.log"),
+    conda:
+        getCondaEnv("bwa_samtools_picard_htslib.yaml")
     params:
         umi_length=lambda wc: config["experiments"][wc.project]["umi_length"],
         datasetID="{condition}.{replicate}.{type}",
-    log:
-        temp(
-            "results/logs/experiment/counts/umi/raw_counts.{project}.{condition}.{replicate}.{type}.log"
-        ),
     shell:
         """
-        samtools view -F 1 -r {params.datasetID} {input} | \
+        samtools merge -o - {input} | samtools view -F 1 -r {params.datasetID} | \
         awk -v 'OFS=\\t' '{{ for (i=12; i<=NF; i++) {{
           if ($i ~ /^XJ:Z:/) print $10,substr($i,6,{params.umi_length})
         }}}}' | \

--- a/workflow/rules/experiment/preprocessing.smk
+++ b/workflow/rules/experiment/preprocessing.smk
@@ -1,22 +1,55 @@
+rule experiment_preprocessing_split_reads:
+    """
+Split the fastq files into n files for parallelisation.
+n is given by split_read in the configuration file.
+"""
+    input:
+        lambda wc: getExperimentReads(
+            wc.read_type, wc.project, wc.condition, wc.replicate, wc.type, check_splitting=False, check_trimming=False
+        ),
+    output:
+        temp(
+            expand(
+                "results/experiments/{{project}}/fastq/{{read_type}}.split.{{condition}}.{{replicate}}.{{type}}.{split}.fastq.gz",
+                split=range(
+                    0,
+                    getMaxExperimentSplitNumber(),
+                ),
+            ),
+        ),
+    log:
+        "results/logs/experiment/preprocessing/split_reads.{project}.{condition}.{replicate}.{type}.{read_type}.log",
+    conda:
+        getCondaEnv("fastqsplitter.yaml")
+    shell:
+        """
+        OUTPUT_FILES=""
+        for file in {output}; do
+            OUTPUT_FILES="${{OUTPUT_FILES}} -o ${{file}}"
+        done
+        fastqsplitter -i <(zcat {input}) -t 1 ${{OUTPUT_FILES}} &> {log}
+        """
+
+
 rule experiment_preprocessing_trim_reads:
     """
-    Getting the BCs from the reads using cutadapt.
-    """
+Getting the BCs from the reads using cutadapt.
+"""
+    input:
+        lambda wc: getExperimentReads(
+            wc.read_type, wc.project, wc.condition, wc.replicate, wc.type, check_splitting=True, check_trimming=False
+        ),
+    output:
+        trimmed_reads="results/experiments/{project}/fastq/{read_type}.trimmed.{condition}.{replicate}.{type}.{split}.fastq.gz",
+    log:
+        "results/logs/experiment/preprocessing/trim_reads.{project}.{condition}.{replicate}.{type}.{split}.{read_type}.log",
+    wildcard_constraints:
+        read_type=r"(FWD)|(REV)|(UMI)",
     conda:
         getCondaEnv("cutadapt.yaml")
     threads: 1
-    input:
-        lambda wc: getReads(
-            wc.read_type, wc.project, wc.condition, wc.replicate, wc.type
-        ),
-    output:
-        trimmed_reads="results/experiments/{project}/fastq/{read_type}.trimmed.{condition}.{replicate}.{type}.fastq.gz",
-    wildcard_constraints:
-        read_type=r"(FWD)|(REV)|(UMI)",
     params:
         adapters=lambda wc: getExperimentCutadaptAdapters(wc.project, wc.read_type),
-    log:
-        "results/logs/experiment/preprocessing/trim_reads.{project}.{condition}.{replicate}.{type}.{read_type}.log",
     shell:
         """
         cutadapt --cores {threads} {params.adapters} \

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -457,6 +457,9 @@ properties:
       ^([^_\.]+)$:
         type: object
         properties:
+          split_number:
+            type: integer
+            default: 1
           bc_length:
             type: integer
             minimum: 1
@@ -680,6 +683,7 @@ properties:
               - min_barcodes
         # entries that have to be in the config file for successful validation
         required:
+          - split_number
           - bc_length
           - data_folder
           - experiment_file


### PR DESCRIPTION
Since BAM files can be huge and merging takes a long time the split enables faster processing and smaller files