### PR TITLE
feat(experiment): :sparkles: NGmerge for paired-end BC reads merging

### DIFF
--- a/docs/1_getting_started/config.rst
+++ b/docs/1_getting_started/config.rst
@@ -100,7 +100,7 @@ For each assignment you want to process, you must give it a name like :code:`exa
     :frac_mismatches_allowed:
         (Optional) Fraction of mismatches allowed in the overlap. Default is :code:`0.1`.
     :min_dovetailed_overlap:
-        (Optional) Minimum dovetailed overlap. Default is :code:`10`.
+        (Optional) Minimum dovetailed overlap. Default is :code:`50`.
 
 :fastq-join:
     (Optional) Options for fastq-join. Fastq-join is used to merge FWD and REV reads. The following options are possible (we recommend using the default values):
@@ -162,6 +162,25 @@ The experiment workflow is configured in the :code:`experiments` section. Each e
     Path to the experiment file. The full or relative path to the file should be used. The experiment file is a comma separated file and is decribed in the `Experiment file`_ section.
 :demultiplex:
     (Optional) If set to :code:`true` the reads are demultiplexed. This means that the reads are split into different files for each barcode. This is usefull for further analysis. Default is :code:`false`.
+:merge_tool:
+    (Optional) Select the read-merging/counting backend for paired-read experiments.
+
+    :custom:
+        Keep the legacy BAM-based path (FastQ2doubleIndexBAM + MergeTrimReadsBAM).
+    :NGmerge:
+        Use NGmerge-based merging for paired reads. This is supported for both no-UMI and UMI experiments.
+
+        - no-UMI: FWD/REV are merged via NGmerge and barcode counts are extracted from merged reads.
+        - UMI: UMI reads are first attached to read headers, then FWD/REV are merged via NGmerge; BCxUMI counts are extracted from merged read headers and sequences.
+
+    Default is :code:`NGmerge`.
+:NGmerge:
+    (Optional) NGmerge options for experiment counts when :code:`merge_tool: NGmerge`.
+
+    :min_overlap:
+        (Optional) Minimum overlap of the reads. NGmerge option :code:`-m`. Default is :code:`11`.
+    :frac_mismatches_allowed:
+        (Optional) Fraction of mismatches allowed in the overlap. NGmerge option :code:`-p`. Default is :code:`0.1`.
 :label_file:
     (Optional) Path to the label file. The full or relative path to the file should be used. The label file is a tab separated file and contais the oligo name and the label of it. The oligo name should be the same as in the design file. The label is used to group the oligos in the final output, e.g. for plotting.
 

--- a/docs/1_getting_started/config.rst
+++ b/docs/1_getting_started/config.rst
@@ -166,14 +166,14 @@ The experiment workflow is configured in the :code:`experiments` section. Each e
     (Optional) Select the read-merging/counting backend for paired-read experiments.
 
     :custom:
-        Keep the legacy BAM-based path (FastQ2doubleIndexBAM + MergeTrimReadsBAM).
+        Keep the legacy BAM-based path (FastQ2doubleIndexBAM + MergeTrimReadsBAM). Slow but better results usually.
     :NGmerge:
-        Use NGmerge-based merging for paired reads. This is supported for both no-UMI and UMI experiments.
+        Use NGmerge-based merging for paired reads. This is supported for both no-UMI and UMI experiments. Usually faster than custom but correlation across replicate smight be lower.
 
         - no-UMI: FWD/REV are merged via NGmerge and barcode counts are extracted from merged reads.
         - UMI: UMI reads are first attached to read headers, then FWD/REV are merged via NGmerge; BCxUMI counts are extracted from merged read headers and sequences.
 
-    Default is :code:`NGmerge`.
+    Default is :code:`custom`.
 :NGmerge:
     (Optional) NGmerge options for experiment counts when :code:`merge_tool: NGmerge`.
 

--- a/workflow/rules/experiment/counts.smk
+++ b/workflow/rules/experiment/counts.smk
@@ -4,6 +4,7 @@
 
 
 include: "counts/counts_demultiplex.smk"
+include: "counts/counts_merge_ngmerge.smk"
 include: "counts/counts_umi.smk"
 include: "counts/counts_noUMI.smk"
 include: "counts/counts_onlyFWD.smk"

--- a/workflow/rules/experiment/counts/counts_merge_ngmerge.smk
+++ b/workflow/rules/experiment/counts/counts_merge_ngmerge.smk
@@ -1,0 +1,28 @@
+######################################
+### Shared merge rule templates    ###
+######################################
+
+
+rule experiment_counts_merge_NGmerge_template:
+    """
+Template rule to merge paired reads using NGmerge.
+"""
+    log:
+        temp("results/logs/experiment/counts/merge_NGmerge.template.{project}.{condition}.{replicate}.{type}.{split}.log"),
+    conda:
+        getCondaEnv("NGmerge.yaml")
+    params:
+        min_overlap=lambda wc: config["experiments"][wc.project].get("NGmerge", {}).get("min_overlap", 11),
+        frac_mismatches_allowed=lambda wc: config["experiments"][wc.project]
+        .get("NGmerge", {})
+        .get("frac_mismatches_allowed", 0.1),
+    shell:
+        """
+        NGmerge \
+        -1 {input.FWD} \
+        -2 {input.REV} \
+        -m {params.min_overlap} -p {params.frac_mismatches_allowed} \
+        -z \
+        -o  {output.join} \
+        -i -f {output.un} &> {log}
+        """

--- a/workflow/rules/experiment/counts/counts_noUMI.smk
+++ b/workflow/rules/experiment/counts/counts_noUMI.smk
@@ -48,6 +48,17 @@ Create a BAM file from FASTQ input, merge FWD and REV read and save UMI in XI fl
         """
 
 
+use rule experiment_counts_merge_NGmerge_template as experiment_counts_noUMI_merge_NGmerge with:
+    input:
+        FWD=lambda wc: getFWD(wc.project, wc.condition, wc.replicate, wc.type, check_splitting=True, check_trimming=True),
+        REV=lambda wc: getREV(wc.project, wc.condition, wc.replicate, wc.type, check_splitting=True, check_trimming=True),
+    output:
+        un=temp("results/experiments/{project}/counts/noUMI.{condition}.{replicate}.{type}.{split}.un.NGmerge.fastq.gz"),
+        join="results/experiments/{project}/counts/noUMI.{condition}.{replicate}.{type}.{split}.join.NGmerge.fastq.gz",
+    log:
+        temp("results/logs/experiment/counts/noUMI/merge_NGmerge.{project}.{condition}.{replicate}.{type}.{split}.log"),
+
+
 ### START COUNTING ####
 
 
@@ -56,9 +67,16 @@ rule experiment_counts_noUMI_raw_counts:
 Counting BCsxUMIs from the BAM files.
 """
     input:
-        expand(
-            "results/experiments/{{project}}/counts/noUMI.{{condition}}.{{replicate}}.{{type}}.{split}.bam",
-            split=range(getMaxExperimentSplitNumber()),
+        lambda wc: (
+            expand(
+                "results/experiments/{{project}}/counts/noUMI.{{condition}}.{{replicate}}.{{type}}.{split}.bam",
+                split=range(getMaxExperimentSplitNumber()),
+            )
+            if config["experiments"][wc.project].get("merge_tool", "NGmerge") == "custom"
+            else expand(
+                "results/experiments/{{project}}/counts/noUMI.{{condition}}.{{replicate}}.{{type}}.{split}.join.NGmerge.fastq.gz",
+                split=range(getMaxExperimentSplitNumber()),
+            )
         ),
     output:
         "results/experiments/{project}/counts/noUMI.{condition}.{replicate}.{type}.raw_counts.tsv.gz",
@@ -68,10 +86,19 @@ Counting BCsxUMIs from the BAM files.
         getCondaEnv("bwa_samtools_picard_htslib.yaml")
     params:
         datasetID="{condition}.{replicate}.{type}",
+        merge_tool=lambda wc: config["experiments"][wc.project].get("merge_tool", "NGmerge"),
     shell:
         """
-        samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
-        awk -v 'OFS=\\t' '{{ print $10 }}' | \
-        sort | \
-        gzip -c > {output} 2> {log}
+        if [[ "{params.merge_tool}" == "custom" ]]; then
+            samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
+            awk -v 'OFS=\\t' '{{ print $10 }}' | \
+            sort | \
+            gzip -c > {output} 2> {log}
+
+        else
+            zcat {input} | \
+            awk 'NR%4==2 {{print $1}}' | \
+            sort | \
+            gzip -c > {output} 2> {log}
+        fi
         """

--- a/workflow/rules/experiment/counts/counts_noUMI.smk
+++ b/workflow/rules/experiment/counts/counts_noUMI.smk
@@ -72,7 +72,7 @@ Counting BCsxUMIs from the BAM files.
                 "results/experiments/{{project}}/counts/noUMI.{{condition}}.{{replicate}}.{{type}}.{split}.bam",
                 split=range(getMaxExperimentSplitNumber()),
             )
-            if config["experiments"][wc.project].get("merge_tool", "NGmerge") == "custom"
+            if config["experiments"][wc.project].get("merge_tool", "custom") == "custom"
             else expand(
                 "results/experiments/{{project}}/counts/noUMI.{{condition}}.{{replicate}}.{{type}}.{split}.join.NGmerge.fastq.gz",
                 split=range(getMaxExperimentSplitNumber()),
@@ -86,18 +86,17 @@ Counting BCsxUMIs from the BAM files.
         getCondaEnv("bwa_samtools_picard_htslib.yaml")
     params:
         datasetID="{condition}.{replicate}.{type}",
-        merge_tool=lambda wc: config["experiments"][wc.project].get("merge_tool", "NGmerge"),
+        merge_tool=lambda wc: config["experiments"][wc.project].get("merge_tool", "custom"),
     shell:
         """
-        if [[ "{params.merge_tool}" == "custom" ]]; then
-            samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
-            awk -v 'OFS=\\t' '{{ print $10 }}' | \
-            sort | \
-            gzip -c > {output} 2> {log}
-
-        else
+        if [[ "{params.merge_tool}" == "NGmerge" ]]; then
             zcat {input} | \
             awk 'NR%4==2 {{print $1}}' | \
+            sort | \
+            gzip -c > {output} 2> {log}
+        else
+            samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
+            awk -v 'OFS=\\t' '{{ print $10 }}' | \
             sort | \
             gzip -c > {output} 2> {log}
         fi

--- a/workflow/rules/experiment/counts/counts_umi.smk
+++ b/workflow/rules/experiment/counts/counts_umi.smk
@@ -49,6 +49,48 @@ Create a BAM file from FASTQ input, merge FWD and REV read and save UMI in XI fl
         """
 
 
+rule experiment_counts_umi_attach_idx:
+    """
+Attach UMI read to FWD/REV headers before NGmerge.
+"""
+    input:
+        read=lambda wc: getExperimentReads(
+            wc.read,
+            wc.project,
+            wc.condition,
+            wc.replicate,
+            wc.type,
+            check_splitting=True,
+            check_trimming=True,
+        ),
+        umi_fastq=lambda wc: getUMI(wc.project, wc.condition, wc.replicate, wc.type, check_splitting=True, check_trimming=True),
+        script=getScript("attachBCToFastQ.py"),
+        libs=getScript("common.py"),
+    output:
+        read=temp(
+            "results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.{read}.{split}.UMIattached.fastq.gz"
+        ),
+    log:
+        temp("results/logs/experiment/counts/umi/attach_idx.{project}.{condition}.{replicate}.{type}.{read}.{split}.log"),
+    conda:
+        getCondaEnv("NGmerge.yaml")
+    shell:
+        """
+        python {input.script} -r {input.read} -b {input.umi_fastq} | bgzip -c > {output.read} 2> {log}
+        """
+
+
+use rule experiment_counts_merge_NGmerge_template as experiment_counts_umi_merge_NGmerge with:
+    input:
+        FWD="results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.FWD.{split}.UMIattached.fastq.gz",
+        REV="results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.REV.{split}.UMIattached.fastq.gz",
+    output:
+        un=temp("results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.{split}.un.NGmerge.fastq.gz"),
+        join="results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.{split}.join.NGmerge.fastq.gz",
+    log:
+        temp("results/logs/experiment/counts/umi/merge_NGmerge.{project}.{condition}.{replicate}.{type}.{split}.log"),
+
+
 ### START COUNTING ####
 
 
@@ -57,13 +99,20 @@ rule experiment_counts_umi_raw_counts:
 Counting BCsxUMIs from the BAM files.
 """
     input:
-        lambda wc: expand(
-            getUMIBamFile(wc.project),
-            project=wc.project,
-            condition=wc.condition,
-            replicate=wc.replicate,
-            type=wc.type,
-            split=range(getMaxExperimentSplitNumber()),
+        lambda wc: (
+            expand(
+                getUMIBamFile(wc.project),
+                project=wc.project,
+                condition=wc.condition,
+                replicate=wc.replicate,
+                type=wc.type,
+                split=range(getMaxExperimentSplitNumber()),
+            )
+            if config["experiments"][wc.project].get("merge_tool", "NGmerge") == "custom"
+            else expand(
+                "results/experiments/{{project}}/counts/useUMI.{{condition}}.{{replicate}}.{{type}}.{split}.join.NGmerge.fastq.gz",
+                split=range(getMaxExperimentSplitNumber()),
+            )
         ),
     output:
         "results/experiments/{project}/counts/useUMI.{condition}.{replicate}.{type}.raw_counts.tsv.gz",
@@ -74,13 +123,28 @@ Counting BCsxUMIs from the BAM files.
     params:
         umi_length=lambda wc: config["experiments"][wc.project]["umi_length"],
         datasetID="{condition}.{replicate}.{type}",
+        merge_tool=lambda wc: config["experiments"][wc.project].get("merge_tool", "NGmerge"),
     shell:
         """
-        samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
-        awk -v 'OFS=\\t' '{{ for (i=12; i<=NF; i++) {{
-          if ($i ~ /^XJ:Z:/) print $10,substr($i,6,{params.umi_length})
-        }}}}' | \
-        sort | uniq -c | \
-        awk -v 'OFS=\\t' '{{ print $2,$3,$1 }}' | \
-        gzip -c > {output} 2> {log}
+        if [[ "{params.merge_tool}" == "custom" ]]; then
+            samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
+            awk -v 'OFS=\\t' '{{ for (i=12; i<=NF; i++) {{
+              if ($i ~ /^XJ:Z:/) print $10,substr($i,6,{params.umi_length})
+            }}}}' | \
+            sort | uniq -c | \
+            awk -v 'OFS=\\t' '{{ print $2,$3,$1 }}' | \
+            gzip -c > {output} 2> {log}
+        else
+            zcat {input} | \
+            awk -v 'OFS=\\t' -v umi_len={params.umi_length} '
+                NR%4==1 {{
+                    umi="";
+                    if (match($0, /XI:Z:([^,[:space:]]+)/, m)) umi=substr(m[1], 1, umi_len)
+                }}
+                NR%4==2 {{if (umi != "") print $1, umi}}
+            ' | \
+            sort | uniq -c | \
+            awk -v 'OFS=\\t' '{{ print $2,$3,$1 }}' | \
+            gzip -c > {output} 2> {log}
+        fi
         """

--- a/workflow/rules/experiment/counts/counts_umi.smk
+++ b/workflow/rules/experiment/counts/counts_umi.smk
@@ -142,7 +142,7 @@ Counting BCsxUMIs from the BAM files.
             awk -v OFS='\\t' -v umi_len={params.umi_length} '
                 NR%4==1 {{
                     umi="";
-                    if (match($0, /XI:Z:([^,[:space:]]+)/, m)) umi=substr(m[1], 1, umi_len)
+                    if (match($0, /XI:Z:[^,[:space:]]+/)) umi=substr($0, RSTART + 5, umi_len)
                 }}
                 NR%4==2 {{if (umi != "") print $1, umi}}
             ' | \

--- a/workflow/rules/experiment/counts/counts_umi.smk
+++ b/workflow/rules/experiment/counts/counts_umi.smk
@@ -111,7 +111,7 @@ Counting BCsxUMIs from the BAM files.
                 type=wc.type,
                 split=range(getMaxExperimentSplitNumber()),
             )
-            if config["experiments"][wc.project].get("merge_tool", "NGmerge") == "custom"
+            if config["experiments"][wc.project].get("merge_tool", "custom") == "custom"
             else expand(
                 "results/experiments/{{project}}/counts/useUMI.{{condition}}.{{replicate}}.{{type}}.{split}.join.NGmerge.fastq.gz",
                 split=range(getMaxExperimentSplitNumber()),
@@ -126,18 +126,10 @@ Counting BCsxUMIs from the BAM files.
     params:
         umi_length=lambda wc: config["experiments"][wc.project]["umi_length"],
         datasetID="{condition}.{replicate}.{type}",
-        merge_tool=lambda wc: config["experiments"][wc.project].get("merge_tool", "NGmerge"),
+        merge_tool=lambda wc: config["experiments"][wc.project].get("merge_tool", "custom"),
     shell:
         """
-        if [[ "{params.merge_tool}" == "custom" ]]; then
-            samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
-            awk -v OFS='\\t' '{{ for (i=12; i<=NF; i++) {{
-              if ($i ~ /^XJ:Z:/) print $10,substr($i,6,{params.umi_length})
-            }}}}' | \
-            sort | uniq -c | \
-            awk -v OFS='\\t' '{{ print $2,$3,$1 }}' | \
-            gzip -c > {output} 2> {log}
-        else
+        if [[ "{params.merge_tool}" == "NGmerge" ]]; then
             zcat {input} | \
             awk -v OFS='\\t' -v umi_len={params.umi_length} '
                 NR%4==1 {{
@@ -146,6 +138,14 @@ Counting BCsxUMIs from the BAM files.
                 }}
                 NR%4==2 {{if (umi != "") print $1, umi}}
             ' | \
+            sort | uniq -c | \
+            awk -v OFS='\\t' '{{ print $2,$3,$1 }}' | \
+            gzip -c > {output} 2> {log}
+        else
+            samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
+            awk -v OFS='\\t' '{{ for (i=12; i<=NF; i++) {{
+              if ($i ~ /^XJ:Z:/) print $10,substr($i,6,{params.umi_length})
+            }}}}' | \
             sort | uniq -c | \
             awk -v OFS='\\t' '{{ print $2,$3,$1 }}' | \
             gzip -c > {output} 2> {log}

--- a/workflow/rules/experiment/counts/counts_umi.smk
+++ b/workflow/rules/experiment/counts/counts_umi.smk
@@ -74,9 +74,12 @@ Attach UMI read to FWD/REV headers before NGmerge.
         temp("results/logs/experiment/counts/umi/attach_idx.{project}.{condition}.{replicate}.{type}.{read}.{split}.log"),
     conda:
         getCondaEnv("NGmerge.yaml")
+    params:
+        read_args=lambda wc, input: " ".join(f"-r {path}" for path in input.read),
+        umi_args=lambda wc, input: " ".join(f"-b {path}" for path in input.umi_fastq),
     shell:
         """
-        python {input.script} -r {input.read} -b {input.umi_fastq} | bgzip -c > {output.read} 2> {log}
+        python {input.script} {params.read_args} {params.umi_args} | bgzip -c > {output.read} 2> {log}
         """
 
 

--- a/workflow/rules/experiment/counts/counts_umi.smk
+++ b/workflow/rules/experiment/counts/counts_umi.smk
@@ -131,15 +131,15 @@ Counting BCsxUMIs from the BAM files.
         """
         if [[ "{params.merge_tool}" == "custom" ]]; then
             samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
-            awk -v 'OFS=\\t' '{{ for (i=12; i<=NF; i++) {{
+            awk -v OFS='\\t' '{{ for (i=12; i<=NF; i++) {{
               if ($i ~ /^XJ:Z:/) print $10,substr($i,6,{params.umi_length})
             }}}}' | \
             sort | uniq -c | \
-            awk -v 'OFS=\\t' '{{ print $2,$3,$1 }}' | \
+            awk -v OFS='\\t' '{{ print $2,$3,$1 }}' | \
             gzip -c > {output} 2> {log}
         else
             zcat {input} | \
-            awk -v 'OFS=\\t' -v umi_len={params.umi_length} '
+            awk -v OFS='\\t' -v umi_len={params.umi_length} '
                 NR%4==1 {{
                     umi="";
                     if (match($0, /XI:Z:([^,[:space:]]+)/, m)) umi=substr(m[1], 1, umi_len)
@@ -147,7 +147,7 @@ Counting BCsxUMIs from the BAM files.
                 NR%4==2 {{if (umi != "") print $1, umi}}
             ' | \
             sort | uniq -c | \
-            awk -v 'OFS=\\t' '{{ print $2,$3,$1 }}' | \
+            awk -v OFS='\\t' '{{ print $2,$3,$1 }}' | \
             gzip -c > {output} 2> {log}
         fi
         """

--- a/workflow/rules/experiment/statistic/counts.smk
+++ b/workflow/rules/experiment/statistic/counts.smk
@@ -150,8 +150,8 @@ rule experiment_statistic_counts_BC_in_RNA_DNA:
 Count the number of barcodes shared between RNA and DNA per condition and replicate.
 """
     input:
-        dna=lambda wc: statistic_counts_BC_in_RNA_DNA_helper(project, wc.condition, "DNA", wc.countType),
-        rna=lambda wc: statistic_counts_BC_in_RNA_DNA_helper(project, wc.condition, "RNA", wc.countType),
+        dna=lambda wc: statistic_counts_BC_in_RNA_DNA_helper(wc.project, wc.condition, "DNA", wc.countType),
+        rna=lambda wc: statistic_counts_BC_in_RNA_DNA_helper(wc.project, wc.condition, "RNA", wc.countType),
     output:
         temp("results/experiments/{project}/statistic/counts/{condition}.{replicate}.{countType}_BC_in_RNA_DNA.tsv.gz"),
     log:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -557,6 +557,25 @@ properties:
           demultiplex:
             type: boolean
             default: false
+          merge_tool:
+            type: string
+            enum:
+              - custom
+              - NGmerge
+            default: NGmerge
+          NGmerge:
+            type: object
+            properties:
+              min_overlap:
+                type: integer
+                default: 11
+              frac_mismatches_allowed:
+                type: number
+                default: 0.1
+            required:
+              - min_overlap
+              - frac_mismatches_allowed
+            default: {}
           label_file:
             type: string
           assignments:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -562,7 +562,7 @@ properties:
             enum:
               - custom
               - NGmerge
-            default: NGmerge
+            default: custom
           NGmerge:
             type: object
             properties:

--- a/workflow/scripts/attachBCToFastQ.py
+++ b/workflow/scripts/attachBCToFastQ.py
@@ -40,24 +40,25 @@ def read_sequence_files(
 
 
 @click.command()
-@click.option("--reads", "-r", "read_file", type=click.Path(exists=True, readable=True), required=True)
-@click.option("--barcodes", "-b", "barcode_file", type=click.Path(exists=True, readable=True), required=True)
+@click.option("--reads", "-r", "read_files", type=click.Path(exists=True, readable=True), required=True, multiple=True)
+@click.option("--barcodes", "-b", "barcode_files", type=click.Path(exists=True, readable=True), required=True, multiple=True)
 @click.option("--reverse-complement", "use_reverse_complement", is_flag=True)
 @click.option(
     "--attach-sequence", "attach_sequence", required=False, type=(click.Choice(["left", "right", "both"]), click.STRING)
 )
-def cli(read_file, barcode_file, use_reverse_complement, attach_sequence):
+def cli(read_files, barcode_files, use_reverse_complement, attach_sequence):
 
-    with gzip.open(read_file, "rt") as r_file, gzip.open(barcode_file, "rt") as bc_file:
-        inputs = {"read_file": r_file, "bc_file": bc_file, "use_BC_reverse_complement": use_reverse_complement}
-        if attach_sequence:
-            if attach_sequence[0] == "left" or attach_sequence[0] == "both":
-                inputs["add_sequence_left"] = attach_sequence[1]
-            if attach_sequence[0] == "right" or attach_sequence[0] == "both":
-                inputs["add_sequence_right"] = reverse_complement(attach_sequence[1])
+    for read_file, barcode_file in zip(read_files, barcode_files):
+        with gzip.open(read_file, "rt") as r_file, gzip.open(barcode_file, "rt") as bc_file:
+            inputs = {"read_file": r_file, "bc_file": bc_file, "use_BC_reverse_complement": use_reverse_complement}
+            if attach_sequence:
+                if attach_sequence[0] == "left" or attach_sequence[0] == "both":
+                    inputs["add_sequence_left"] = attach_sequence[1]
+                if attach_sequence[0] == "right" or attach_sequence[0] == "both":
+                    inputs["add_sequence_right"] = reverse_complement(attach_sequence[1])
 
-        for seqid, seq, qual in read_sequence_files(**inputs):
-            click.echo(f"@{seqid}\n{seq}\n+\n{qual}")
+            for seqid, seq, qual in read_sequence_files(**inputs):
+                click.echo(f"@{seqid}\n{seq}\n+\n{qual}")
 
 
 def reverse_complement(seq):


### PR DESCRIPTION
NGmerge can replace the custom merge script with bam files

custom is the other option name and will stay default. NGmerge is much faster but custom seems to produce better results (number of BCs and correlation across replicates)