### PR TITLE
feat(assignment)!: cigar filtering for BWA and optional length filter

### DIFF
--- a/config/example_assignment_bbmap.yaml
+++ b/config/example_assignment_bbmap.yaml
@@ -1,5 +1,5 @@
 ---
-version: "0.6"
+version: "0.7"
 assignments:
   exampleAssignment: # name of an example assignment (can be any string)
     bc_length: 15
@@ -8,8 +8,6 @@ assignments:
       tool: bbmap
       configs:
         min_mapping_quality: 30 # 30 is default for bbmap
-        sequence_length: 171 # sequence length of design excluding adapters.
-        alignment_start: 1 # start of an alignment in the reference/design_file.
     FWD:
       - resources/Assignment_BasiC/R1.fastq.gz
     BC:
@@ -17,5 +15,8 @@ assignments:
     REV:
       - resources/Assignment_BasiC/R3.fastq.gz
     design_file: resources/design.fa
+    design_check:
+      sequence_start: 1 # start of an alignment in the reference/design_file.
+      sequence_length: 171 # sequence length of design excluding adapters.
     configs:
       default: {} # name of an example filtering config

--- a/config/example_assignment_bwa.yaml
+++ b/config/example_assignment_bwa.yaml
@@ -1,5 +1,5 @@
 ---
-version: "0.6"
+version: "0.7"
 assignments:
   exampleAssignment: # name of an example assignment (can be any string)
     bc_length: 15

--- a/config/example_assignment_exact_lazy.yaml
+++ b/config/example_assignment_exact_lazy.yaml
@@ -1,5 +1,5 @@
 ---
-version: "0.6"
+version: "0.7"
 assignments:
   exampleAssignment: # name of an example assignment (can be any string)
     bc_length: 15

--- a/config/example_assignment_exact_linker.yaml
+++ b/config/example_assignment_exact_linker.yaml
@@ -1,5 +1,5 @@
 ---
-version: "0.6"
+version: "0.7"
 assignments:
   exampleAssignment: # name of an example assignment (can be any string)
     bc_length: 20

--- a/config/example_assignment_pbmm2.yaml
+++ b/config/example_assignment_pbmm2.yaml
@@ -1,18 +1,19 @@
 ---
-version: "0.6"
+version: "0.7"
 
 assignments:
   exampleLongRead:
     bc_length: 15
     long_read_input: resources/long_read/CEBPRE_10k.bam
     design_file: resources/long_read/CEBPRE_reference.fasta
+    design_check:
+      sequence_start: 1
+      sequence_length: 303
     alignment_tool:
       tool: pbmm2
       configs:
         preset: SUBREAD
         min_concordance: 0.9
-        alignment_start: 1
-        sequence_length: 303
     linker: GCAAAGTGAACACATCGCTAAGCGAAAGCTAAG # linker sequence in the read after we expect the BC
     configs:
       test:

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -1,5 +1,5 @@
 ---
-version: "0.6"
+version: "0.7"
 assignments:
   exampleAssignment: # name of an example assignment (can be any string)
     bc_length: 15

--- a/config/example_count.yaml
+++ b/config/example_count.yaml
@@ -1,5 +1,5 @@
 ---
-version: "0.6"
+version: "0.7"
 experiments:
   exampleCount:
     bc_length: 15

--- a/docs/1_getting_started/config.rst
+++ b/docs/1_getting_started/config.rst
@@ -59,6 +59,8 @@ For each assignment you want to process, you must give it a name like :code:`exa
             Defines the :code:`min` and :code:`max` of the start of the alignment in an oligo. When using adapters, you must set the length of the adapter. Otherwise, 1 will be the choice for most cases. We also recommend varying this value slightly because the start might not be exact after the adapter (e.g., ±1).
         :min_mapping_quality (bwa, bwa-additional-filtering, bbmap):
             (Optional) Defines the minimum mapping quality (MAPQ) of the alignment to an oligo. MAPQs differ between bbmap and bwa. For bwa: When using oligos with only 1bp difference, it is recommended to set it to 1 (bwa default is :code:`1`). BBMap is better here, and we can use, for example, 30 or 35. For regions with larger edit distances, 30 or 40 might be a good choice. Default is :code:`30` (bbmap).
+        :cigar_filter_regex (bwa, bbmap):
+            (Optional) Regular expression to filter alignments by CIGAR string before barcode assignment. The full CIGAR string must match. Example values are :code:`200M` or :code:`200M|210M`. If not set, no CIGAR-based filtering is applied.
         :M: (bwa, bwa-additional-filtering):
             (Optional) BWA option :code:`-M`: Mark shorter split hits as secondary. Default is :code:`true`.
         :L: (bwa, bwa-additional-filtering):

--- a/docs/1_getting_started/config.rst
+++ b/docs/1_getting_started/config.rst
@@ -49,14 +49,14 @@ For each assignment you want to process, you must give it a name like :code:`exa
     :configs:
         Configurations of the alignment tool selected.
 
-        :sequence_length (exact, bbmap, pbmm2):
+        :sequence_length (exact, bwa-additional-filtering):
             Defines the :code:`sequence_length`, which is the length of a sequence alignment to an oligo in the design file. Only one length design is supported.
-        :alignment_start (exact, bbmap, pbmm2):
+        :alignment_start (exact):
             Defines the start of the alignment in an oligo. When using adapters, you must set the length of the adapter. Otherwise, 1 will be the choice for most cases.
-        :sequence_length (bwa, bwa-additional-filtering):
-            Defines the :code:`min` and :code:`max` of a :code:`sequence_length` specification. :code:`sequence_length` is the length of a sequence alignment to an oligo in the design file. Because there can be insertions and deletions, we recommend varying it slightly around the exact length (e.g., ±5). This option enables designs with multiple sequence lengths.
-        :alignment_start (bwa, bwa-additional-filtering):
-            Defines the :code:`min` and :code:`max` of the start of the alignment in an oligo. When using adapters, you must set the length of the adapter. Otherwise, 1 will be the choice for most cases. We also recommend varying this value slightly because the start might not be exact after the adapter (e.g., ±1).
+        :sequence_length (bwa):
+            (Optiona) Defines the :code:`min` and :code:`max` of a :code:`sequence_length` specification. :code:`sequence_length` is the length of a sequence alignment to an oligo in the design file. Because there can be insertions and deletions, we recommend varying it slightly around the exact length (e.g., ±5). This option enables designs with multiple sequence lengths.
+        :alignment_start (bwa):
+            (Optional) Defines the :code:`min` and :code:`max` of the start of the alignment in an oligo. When using adapters, you must set the length of the adapter. Otherwise, 1 will be the choice for most cases. We also recommend varying this value slightly because the start might not be exact after the adapter (e.g., ±1).
         :min_mapping_quality (bwa, bwa-additional-filtering, bbmap):
             (Optional) Defines the minimum mapping quality (MAPQ) of the alignment to an oligo. MAPQs differ between bbmap and bwa. For bwa: When using oligos with only 1bp difference, it is recommended to set it to 1 (bwa default is :code:`1`). BBMap is better here, and we can use, for example, 30 or 35. For regions with larger edit distances, 30 or 40 might be a good choice. Default is :code:`30` (bbmap).
         :cigar_filter_regex (bwa, bbmap):
@@ -121,6 +121,12 @@ For each assignment you want to process, you must give it a name like :code:`exa
         (Optional) Use a simple dictionary to find identical sequences. This is faster but uses only the whole (or center part depending on start/length) of the design file. Cannot find substrings as part of any sequence. Set to false for more correct, but slower, search. Default is :code:`true`.
     :sequence_collisions:
         (Optional) Check if there are identical sequences in the design file. Default is :code:`true`.
+    :sequence_start:
+        (Conditionally required) 1-based start position used for sequence collision checking.
+        Required only when :code:`sequence_collisions` is set to :code:`true` and no alignment_start is defined via the mapping tool config (bwa or exact).
+    :sequence_length:
+        (Conditionally required) Number of bases used for sequence collision checking.
+        Required only when :code:`sequence_collisions` is set to :code:`true` and no sequence_length is defined via the mapping tool config (bwa, bwa-additional-filtering, or exact).
 :strand_sensitive:
     (Optional) If enabled, the reads are mapped to the oligos in a strand-sensitive way by adding unique adapters to both ends of the oligo reference as well as the FASTQ files. By default, this option is not enabled.
 

--- a/workflow/rules/assignment.smk
+++ b/workflow/rules/assignment.smk
@@ -48,10 +48,10 @@ Also check if no duplicated headers and no illegal characters in header.
         trap "cat {log.err}" ERR
         cp {input.design} {output.ref_tmp}
         python {input.script} --input {output.ref_tmp} \
-        --output {output.ref} \
-        {params.start_length_args} \
-        {params.fast_check} --sequence-check {params.sequence_collisions} \
-        {params.attach_sequence} > {log.log} 2> {log.err};
+            --output {output.ref} \
+            {params.start_length_args} \
+            {params.fast_check} --sequence-check {params.sequence_collisions} \
+            {params.attach_sequence} >{log.log} 2>{log.err}
         """
 
 
@@ -99,7 +99,7 @@ Runs only if the design file is correct.
         ),
     shell:
         """
-        fastqsplitter -i <(zcat {input.fastq}) -t 1 {params.files} &> {log}
+        fastqsplitter -i <(zcat {input.fastq}) -t 1 {params.files} &>{log}
         """
 
 
@@ -132,7 +132,7 @@ Extract the index sequence and add it to the header.
         ),
     shell:
         """
-        python {input.script} -r {input.read} -b {input.BC} {params.BC_rev_comp} {params.attach_sequence} | bgzip -c > {output.read} 2> {log}
+        python {input.script} -r {input.read} -b {input.BC} {params.BC_rev_comp} {params.attach_sequence} | bgzip -c >{output.read} 2>{log}
         """
 
 
@@ -157,14 +157,14 @@ Merge the FWD, REV and BC fastq files into one using NGmerge.
     shell:
         """
         NGmerge \
-        -1 {input.FWD} \
-        -2 {input.REV} \
-        -m {params.min_overlap} -p {params.frac_mismatches_allowed} \
-        -d \
-        -e {params.min_dovetailed_overlap} \
-        -z \
-        -o  {output.join} \
-        -i -f {output.un} &> {log}
+            -1 {input.FWD} \
+            -2 {input.REV} \
+            -m {params.min_overlap} -p {params.frac_mismatches_allowed} \
+            -d \
+            -e {params.min_dovetailed_overlap} \
+            -z \
+            -o {output.join} \
+            -i -f {output.un} &>{log}
         """
 
 
@@ -189,7 +189,7 @@ Merge the FWD, REV and BC fastq files into one using fastq-join.
     shell:
         """
         fastq-join -p {params.min_overlap} -m {params.max_pct_mismatch} {input.FWD} {input.REV} \
-        -o {output.un1} -o {output.un2} -o {output.join} &> {log}
+            -o {output.un1} -o {output.un2} -o {output.join} &>{log}
         """
 
 
@@ -227,8 +227,8 @@ Get the barcodes.
     shell:
         """
         export LC_ALL=C # speed up sort
-        sort -S 7G {params.batch_size} --parallel={threads} -k1,1 -k2,2 -k3,3 -m {input} | \
-        gzip -c > {output} 2> {log}
+        sort -S 7G {params.batch_size} --parallel={threads} -k1,1 -k2,2 -k3,3 -m {input} \
+            | gzip -c >{output} 2>{log}
         """
 
 
@@ -257,12 +257,12 @@ FIXME: Limitation is that oligos cannot have a name ambiguous or other.
     shell:
         """
         trap "cat {log.err}" ERR
-        zcat  {input.assignment} | \
-        awk -v "OFS=\\t" -F"\\t" '{{if (length($1)=={params.bc_length}){{print $0 }}}}' | \
-        python {input.script} \
-        -m {params.min_support} -f {params.fraction} {params.unknown_other} {params.ambiguous} | \
-        tee >(gzip -c > {output.ambiguous}) | \
-        awk -v "OFS=\\t"  -F"\\t" '{{ if (($2 != \"ambiguous\") && ($2 != \"other\")) {{ print $1,$2 }} }}' | \
-        gzip -c > {output.final} 2> {log.err};
+        zcat {input.assignment} \
+            | awk -v "OFS=\\t" -F"\\t" '{{if (length($1)=={params.bc_length}){{print $0 }}}}' \
+            | python {input.script} \
+                -m {params.min_support} -f {params.fraction} {params.unknown_other} {params.ambiguous} \
+            | tee >(gzip -c >{output.ambiguous}) \
+            | awk -v "OFS=\\t" -F"\\t" '{{ if (($2 != \"ambiguous\") && ($2 != \"other\")) {{ print $1,$2 }} }}' \
+            | gzip -c >{output.final} 2>{log.err}
         gzip -l {output.final} | awk 'NR==2 {{exit($2==0)}}' || {{ echo "Error: Empty barcode file {output.final}. No barcodes detected!" >> {log.err}; exit 1; }}
         """

--- a/workflow/rules/assignment.smk
+++ b/workflow/rules/assignment.smk
@@ -31,30 +31,9 @@ Also check if no duplicated headers and no illegal characters in header.
     conda:
         getCondaEnv("python3.yaml")
     params:
-        start=lambda wc: (
-            config["assignments"][wc.assignment]["alignment_tool"]["configs"]["alignment_start"]["max"]
-            if config["assignments"][wc.assignment]["alignment_tool"]["tool"]
-            in [
-                "bwa",
-                "bwa-additional-filtering",
-            ]
-            else config["assignments"][wc.assignment]["alignment_tool"]["configs"]["alignment_start"]
-        ),
-        length=lambda wc: (
-            config["assignments"][wc.assignment]["alignment_tool"]["configs"]["sequence_length"]["min"]
-            if config["assignments"][wc.assignment]["alignment_tool"]["tool"]
-            in [
-                "bwa",
-                "bwa-additional-filtering",
-            ]
-            else config["assignments"][wc.assignment]["alignment_tool"]["configs"]["sequence_length"]
-        ),
-        fast_check=lambda wc: (
-            "--fast-dict" if config["assignments"][wc.assignment]["design_check"]["fast"] else "--slow-string-search"
-        ),
-        sequence_collisions=lambda wc: (
-            "sense_antisense" if config["assignments"][wc.assignment]["design_check"]["sequence_collisions"] else "skip"
-        ),
+        start_length_args=lambda wc: getDesignCheckWindowArgs(wc.assignment),
+        fast_check=lambda wc: ("--fast-dict" if getDesignCheckFast(wc.assignment) else "--slow-string-search"),
+        sequence_collisions=lambda wc: ("sense_antisense" if getDesignCheckSequenceCollisions(wc.assignment) else "skip"),
         attach_sequence=lambda wc: (
             "--attach-sequence %s %s"
             % (
@@ -70,7 +49,7 @@ Also check if no duplicated headers and no illegal characters in header.
         cp {input.design} {output.ref_tmp}
         python {input.script} --input {output.ref_tmp} \
         --output {output.ref} \
-        --start {params.start} --length {params.length} \
+        {params.start_length_args} \
         {params.fast_check} --sequence-check {params.sequence_collisions} \
         {params.attach_sequence} > {log.log} 2> {log.err};
         """

--- a/workflow/rules/assignment/common.smk
+++ b/workflow/rules/assignment/common.smk
@@ -95,3 +95,25 @@ def getAssignmentCutadaptAdapters(assignment: str, read: str) -> str:
 
             return " ".join(output)
     return " ".join(output)
+
+
+def getDesignCheckConfig(assignment: str) -> dict:
+    return config["assignments"][assignment].get("design_check")
+
+
+def getDesignCheckSequenceCollisions(assignment: str) -> bool:
+    return getDesignCheckConfig(assignment).get("sequence_collisions")
+
+
+def getDesignCheckFast(assignment: str) -> bool:
+    return getDesignCheckConfig(assignment).get("fast")
+
+
+def getDesignCheckWindowArgs(assignment):
+    if not getDesignCheckSequenceCollisions(assignment):
+        return ""
+
+    start = getDesignCheckConfig(assignment).get("sequence_start")
+    length = getDesignCheckConfig(assignment).get("sequence_length")
+
+    return f"--start {start} --length {length}"

--- a/workflow/rules/assignment/hybridFWDRead.smk
+++ b/workflow/rules/assignment/hybridFWDRead.smk
@@ -31,13 +31,14 @@ Get the barcode and read from the FWD read using fixed length
         + 1,
     shell:
         """
-        zcat {input.fastq} | \
-        awk '{{if (NR%4==2 || NR%4==0){{
-                print substr($0,1,{params.bc_length}) > "{output.BC_tmp}"; print substr($0,{params.insert_start}) > "{output.FWD_tmp}"
-            }} else {{
-                print $0 > "{output.BC_tmp}"; print $0 > "{output.FWD_tmp}"
-            }}}}';
-        cat {output.BC_tmp} | bgzip > {output.BC} & cat {output.FWD_tmp} | bgzip > {output.FWD};
+        zcat {input.fastq} \
+            | awk '{{if (NR%4==2 || NR%4==0){{
+                                                        print substr($0,1,{params.bc_length}) > "{output.BC_tmp}"; print substr($0,{params.insert_start}) > "{output.FWD_tmp}"
+                                                    }} else {{
+                                                        print $0 > "{output.BC_tmp}"; print $0 > "{output.FWD_tmp}"
+                                                    }}}}'
+        cat {output.BC_tmp} | bgzip >{output.BC} &
+        cat {output.FWD_tmp} | bgzip >{output.FWD}
         """
 
 
@@ -64,6 +65,5 @@ Uses the paired end mode of cutadapt to write the FWD and BC read.
         linker=lambda wc: config["assignments"][wc.assignment]["linker"],
     shell:
         """
-        cutadapt --cores {threads} -a {params.linker} -G {params.linker}\
-        -o {output.BC} -p {output.FWD} <(zcat {input}) <(zcat {input}) &> {log}
+        cutadapt --cores {threads} -a {params.linker} -G {params.linker} -o {output.BC} -p {output.FWD} <(zcat {input}) <(zcat {input}) &>{log}
         """

--- a/workflow/rules/assignment/mapping_bbmap.smk
+++ b/workflow/rules/assignment/mapping_bbmap.smk
@@ -39,8 +39,8 @@ Map the reads to the reference and sort unsing bwa mem
     shell:
         """
         bbmap.sh -eoom -Xmx{resources.mem_mb}M -t={threads} nullifybrokenquality \
-        in={input.reads} ref={input.reference} nodisk out={output.bam} &> {log};
-        samtools sort -l 0 -@ {threads} {output.bam} > {output.sorted_bam} 2>> {log};
+            in={input.reads} ref={input.reference} nodisk out={output.bam} &>{log}
+        samtools sort -l 0 -@ {threads} {output.bam} >{output.sorted_bam} 2>>{log}
         """
 
 
@@ -74,18 +74,18 @@ BAM/SAM fields:
     shell:
         """
         export LC_ALL=C # speed up sorting
-        samtools view -F 1792 {input} | \
-        awk -F"\\t" -v "OFS=\\t" -v "CIGAR_REGEX={params.cigar_filter_regex}" '{{
-            split($1,a," ");
-            split(a[2],a,":");
-            split(a[3],a,",");
-            if (a[1] !~ /N/) {{
-                pass_cigar = (CIGAR_REGEX == "" || $6 ~ ("^(" CIGAR_REGEX ")$"));
-                if (pass_cigar && ($5 >= {params.mapping_quality_min}) && ($4 >= 1)) {{
-                    print a[1],$3,$4";"$6";"$12";"$13";"$5
-                }} else {{
-                    print a[1],"other","NA"
-                }}
-            }}
-        }}' | sort -k1,1 -k2,2 -k3,3 -S 7G > {output} 2> {log}
+        samtools view -F 1792 {input} \
+            | awk -F"\\t" -v "OFS=\\t" -v "CIGAR_REGEX={params.cigar_filter_regex}" '{{
+                                                    split($1,a," ");
+                                                    split(a[2],a,":");
+                                                    split(a[3],a,",");
+                                                    if (a[1] !~ /N/) {{
+                                                        pass_cigar = (CIGAR_REGEX == "" || $6 ~ ("^(" CIGAR_REGEX ")$"));
+                                                        if (pass_cigar && ($5 >= {params.mapping_quality_min}) && ($4 >= 1)) {{
+                                                            print a[1],$3,$4";"$6";"$12";"$13";"$5
+                                                        }} else {{
+                                                            print a[1],"other","NA"
+                                                        }}
+                                                    }}
+                                                }}' | sort -k1,1 -k2,2 -k3,3 -S 7G >{output} 2>{log}
         """

--- a/workflow/rules/assignment/mapping_bbmap.smk
+++ b/workflow/rules/assignment/mapping_bbmap.smk
@@ -68,16 +68,20 @@ BAM/SAM fields:
         getCondaEnv("bbmap_samtools_htslib.yaml")
     params:
         mapping_quality_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["min_mapping_quality"],
+        cigar_filter_regex=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"].get(
+            "cigar_filter_regex", ""
+        ),
     shell:
         """
         export LC_ALL=C # speed up sorting
         samtools view -F 1792 {input} | \
-        awk -F"\\t" -v "OFS=\\t" '{{
+        awk -F"\\t" -v "OFS=\\t" -v "CIGAR_REGEX={params.cigar_filter_regex}" '{{
             split($1,a," ");
             split(a[2],a,":");
             split(a[3],a,",");
             if (a[1] !~ /N/) {{
-                if (($5 >= {params.mapping_quality_min}) && ($4 >= 1)) {{
+                pass_cigar = (CIGAR_REGEX == "" || $6 ~ ("^(" CIGAR_REGEX ")$"));
+                if (pass_cigar && ($5 >= {params.mapping_quality_min}) && ($4 >= 1)) {{
                     print a[1],$3,$4";"$6";"$12";"$13";"$5
                 }} else {{
                     print a[1],"other","NA"

--- a/workflow/rules/assignment/mapping_bwa.smk
+++ b/workflow/rules/assignment/mapping_bwa.smk
@@ -70,18 +70,18 @@ Get the barcodes.
     conda:
         getCondaEnv("bwa_samtools_picard_htslib.yaml")
     params:
-        alignment_start_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["alignment_start"][
-            "min"
-        ],
-        alignment_start_max=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["alignment_start"][
-            "max"
-        ],
-        sequence_length_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["sequence_length"][
-            "min"
-        ],
-        sequence_length_max=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["sequence_length"][
-            "max"
-        ],
+        alignment_start_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]
+        .get("alignment_start", {})
+        .get("min", ""),
+        alignment_start_max=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]
+        .get("alignment_start", {})
+        .get("max", ""),
+        sequence_length_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]
+        .get("sequence_length", {})
+        .get("min", ""),
+        sequence_length_max=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]
+        .get("sequence_length", {})
+        .get("max", ""),
         mapping_quality_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["min_mapping_quality"],
         cigar_filter_regex=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"].get(
             "cigar_filter_regex", ""
@@ -90,12 +90,19 @@ Get the barcodes.
         """
         export LC_ALL=C # speed up sorting
         samtools view -F 1792 {input} | \
-        awk -v "OFS=\\t" -v "CIGAR_REGEX={params.cigar_filter_regex}" '{{
+        awk -v "OFS=\\t" \
+            -v "CIGAR_REGEX={params.cigar_filter_regex}" \
+            -v "ALIGNMENT_START_MIN={params.alignment_start_min}" \
+            -v "ALIGNMENT_START_MAX={params.alignment_start_max}" \
+            -v "SEQUENCE_LENGTH_MIN={params.sequence_length_min}" \
+            -v "SEQUENCE_LENGTH_MAX={params.sequence_length_max}" '{{
             split($(NF),a,":");
             split(a[3],a,",");
             if (a[1] !~ /N/) {{
                 pass_cigar = (CIGAR_REGEX == "" || $6 ~ ("^(" CIGAR_REGEX ")$"));
-                if (pass_cigar && ($5 >= {params.mapping_quality_min}) && ($4 >= {params.alignment_start_min}) && ($4 <= {params.alignment_start_max}) && (length($10) >= {params.sequence_length_min}) && (length($10) <= {params.sequence_length_max})) {{
+                pass_alignment_start = ((ALIGNMENT_START_MIN == "" || $4 >= ALIGNMENT_START_MIN) && (ALIGNMENT_START_MAX == "" || $4 <= ALIGNMENT_START_MAX));
+                pass_sequence_length = ((SEQUENCE_LENGTH_MIN == "" || length($10) >= SEQUENCE_LENGTH_MIN) && (SEQUENCE_LENGTH_MAX == "" || length($10) <= SEQUENCE_LENGTH_MAX));
+                if (pass_cigar && ($5 >= {params.mapping_quality_min}) && pass_alignment_start && pass_sequence_length) {{
                     print a[1],$3,$4";"$6";"$12";"$13";"$5
                 }} else {{
                     print a[1],"other","NA"
@@ -125,7 +132,7 @@ Get the barcodes with a python script to rescue alignments with 0 mapping qualit
         ],
         expected_alignment_length=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"][
             "sequence_length"
-        ]["min"],
+        ],
         verbose=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["verbose"],
         min_mapping_quality=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["min_mapping_quality"],
     shell:

--- a/workflow/rules/assignment/mapping_bwa.smk
+++ b/workflow/rules/assignment/mapping_bwa.smk
@@ -83,15 +83,19 @@ Get the barcodes.
             "max"
         ],
         mapping_quality_min=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"]["min_mapping_quality"],
+        cigar_filter_regex=lambda wc: config["assignments"][wc.assignment]["alignment_tool"]["configs"].get(
+            "cigar_filter_regex", ""
+        ),
     shell:
         """
         export LC_ALL=C # speed up sorting
         samtools view -F 1792 {input} | \
-        awk -v "OFS=\\t" '{{
+        awk -v "OFS=\\t" -v "CIGAR_REGEX={params.cigar_filter_regex}" '{{
             split($(NF),a,":");
             split(a[3],a,",");
             if (a[1] !~ /N/) {{
-                if (($5 >= {params.mapping_quality_min}) && ($4 >= {params.alignment_start_min}) && ($4 <= {params.alignment_start_max}) && (length($10) >= {params.sequence_length_min}) && (length($10) <= {params.sequence_length_max})) {{
+                pass_cigar = (CIGAR_REGEX == "" || $6 ~ ("^(" CIGAR_REGEX ")$"));
+                if (pass_cigar && ($5 >= {params.mapping_quality_min}) && ($4 >= {params.alignment_start_min}) && ($4 <= {params.alignment_start_max}) && (length($10) >= {params.sequence_length_min}) && (length($10) <= {params.sequence_length_max})) {{
                     print a[1],$3,$4";"$6";"$12";"$13";"$5
                 }} else {{
                     print a[1],"other","NA"

--- a/workflow/rules/assignment/mapping_bwa.smk
+++ b/workflow/rules/assignment/mapping_bwa.smk
@@ -17,9 +17,9 @@ Create mapping reference for BWA from design file.
         getCondaEnv("bwa_samtools_picard_htslib.yaml")
     shell:
         """
-        bwa index -a bwtsw {input.ref} &> {log};
-        samtools faidx {input.ref} &>> {log};
-        picard CreateSequenceDictionary REFERENCE={input.ref} OUTPUT={output.d} &>> {log}
+        bwa index -a bwtsw {input.ref} &>{log}
+        samtools faidx {input.ref} &>>{log}
+        picard CreateSequenceDictionary REFERENCE={input.ref} OUTPUT={output.d} &>>{log}
         """
 
 
@@ -53,7 +53,7 @@ Map the reads to the reference and sort unsing bwa mem
         """
         bwa mem -t {threads} -L {params.L} {params.M} -C {input.reference} <(
             gzip -dc {input.reads}
-        )  | samtools sort -l 0 -@ {threads} > {output} 2> {log}
+        ) | samtools sort -l 0 -@ {threads} >{output} 2>{log}
         """
 
 
@@ -89,26 +89,26 @@ Get the barcodes.
     shell:
         """
         export LC_ALL=C # speed up sorting
-        samtools view -F 1792 {input} | \
-        awk -v "OFS=\\t" \
-            -v "CIGAR_REGEX={params.cigar_filter_regex}" \
-            -v "ALIGNMENT_START_MIN={params.alignment_start_min}" \
-            -v "ALIGNMENT_START_MAX={params.alignment_start_max}" \
-            -v "SEQUENCE_LENGTH_MIN={params.sequence_length_min}" \
-            -v "SEQUENCE_LENGTH_MAX={params.sequence_length_max}" '{{
-            split($(NF),a,":");
-            split(a[3],a,",");
-            if (a[1] !~ /N/) {{
-                pass_cigar = (CIGAR_REGEX == "" || $6 ~ ("^(" CIGAR_REGEX ")$"));
-                pass_alignment_start = ((ALIGNMENT_START_MIN == "" || $4 >= ALIGNMENT_START_MIN) && (ALIGNMENT_START_MAX == "" || $4 <= ALIGNMENT_START_MAX));
-                pass_sequence_length = ((SEQUENCE_LENGTH_MIN == "" || length($10) >= SEQUENCE_LENGTH_MIN) && (SEQUENCE_LENGTH_MAX == "" || length($10) <= SEQUENCE_LENGTH_MAX));
-                if (pass_cigar && ($5 >= {params.mapping_quality_min}) && pass_alignment_start && pass_sequence_length) {{
-                    print a[1],$3,$4";"$6";"$12";"$13";"$5
-                }} else {{
-                    print a[1],"other","NA"
-                }}
-            }}
-        }}' | sort -k1,1 -k2,2 -k3,3 -S 7G > {output} 2> {log}
+        samtools view -F 1792 {input} \
+            | awk -v "OFS=\\t" \
+                -v "CIGAR_REGEX={params.cigar_filter_regex}" \
+                -v "ALIGNMENT_START_MIN={params.alignment_start_min}" \
+                -v "ALIGNMENT_START_MAX={params.alignment_start_max}" \
+                -v "SEQUENCE_LENGTH_MIN={params.sequence_length_min}" \
+                -v "SEQUENCE_LENGTH_MAX={params.sequence_length_max}" '{{
+                                                    split($(NF),a,":");
+                                                    split(a[3],a,",");
+                                                    if (a[1] !~ /N/) {{
+                                                        pass_cigar = (CIGAR_REGEX == "" || $6 ~ ("^(" CIGAR_REGEX ")$"));
+                                                        pass_alignment_start = ((ALIGNMENT_START_MIN == "" || $4 >= ALIGNMENT_START_MIN) && (ALIGNMENT_START_MAX == "" || $4 <= ALIGNMENT_START_MAX));
+                                                        pass_sequence_length = ((SEQUENCE_LENGTH_MIN == "" || length($10) >= SEQUENCE_LENGTH_MIN) && (SEQUENCE_LENGTH_MAX == "" || length($10) <= SEQUENCE_LENGTH_MAX));
+                                                        if (pass_cigar && ($5 >= {params.mapping_quality_min}) && pass_alignment_start && pass_sequence_length) {{
+                                                            print a[1],$3,$4";"$6";"$12";"$13";"$5
+                                                        }} else {{
+                                                            print a[1],"other","NA"
+                                                        }}
+                                                    }}
+                                                }}' | sort -k1,1 -k2,2 -k3,3 -S 7G >{output} 2>{log}
         """
 
 
@@ -138,9 +138,9 @@ Get the barcodes with a python script to rescue alignments with 0 mapping qualit
     shell:
         """
         python {input.script} \
-        --identity_threshold {params.identity_threshold} --mismatches_threshold {params.mismatches_threshold} \
-        --expected_alignment_length {params.expected_alignment_length} \
-        --min_mapping_quality {params.min_mapping_quality} --bamfile {input.bam} --verbose {params.verbose} --output {output} 2> {log} && sort -k1,1 -k2,2 -k3,3 -o {output} {output}
+            --identity_threshold {params.identity_threshold} --mismatches_threshold {params.mismatches_threshold} \
+            --expected_alignment_length {params.expected_alignment_length} \
+            --min_mapping_quality {params.min_mapping_quality} --bamfile {input.bam} --verbose {params.verbose} --output {output} 2>{log} && sort -k1,1 -k2,2 -k3,3 -o {output} {output}
         """
 
 
@@ -163,7 +163,7 @@ Collect mapped reads.
     threads: 1
     shell:
         """
-        samtools merge -@ {threads} {output} {input.bams} 2> {log}
+        samtools merge -@ {threads} {output} {input.bams} 2>{log}
         """
 
 
@@ -181,7 +181,7 @@ Index the BAM file
         getCondaEnv("bwa_samtools_picard_htslib.yaml")
     shell:
         """
-        samtools index {input} 2> {log}
+        samtools index {input} 2>{log}
         """
 
 
@@ -200,5 +200,5 @@ Run samtools flagstat
         getCondaEnv("bwa_samtools_picard_htslib.yaml")
     shell:
         """
-        samtools flagstat {input.bam} > {output} 2> {log}
+        samtools flagstat {input.bam} >{output} 2>{log}
         """

--- a/workflow/rules/assignment/mapping_exact.smk
+++ b/workflow/rules/assignment/mapping_exact.smk
@@ -14,12 +14,12 @@ Create reference to map the exact design
     shell:
         """
         paste <(
-            cat {input.ref} | awk '{{if ($1 ~ /^>/) {{ print substr($1,2)}}}}';
-            cat {input.ref} | awk '{{if ($1 ~ /^>/) {{ print substr($1,2)}}}}';
+            cat {input.ref} | awk '{{if ($1 ~ /^>/) {{ print substr($1,2)}}}}'
+            cat {input.ref} | awk '{{if ($1 ~ /^>/) {{ print substr($1,2)}}}}'
         ) <(
-            cat {input.ref} | awk '{{if ($1 ~ /^[^>]/) {{ seq=seq$1}}; if ($1 ~ /^>/ && NR!=1) {{print seq; seq=""}}}} END {{print seq}}';
-            cat {input.ref} | awk '{{if ($1 ~ /^[^>]/) {{ seq=seq$1}}; if ($1 ~ /^>/ && NR!=1) {{print seq; seq=""}}}} END {{print seq}}' | tr ACGTacgt TGCAtgca | rev;
-        ) > {output}
+            cat {input.ref} | awk '{{if ($1 ~ /^[^>]/) {{ seq=seq$1}}; if ($1 ~ /^>/ && NR!=1) {{print seq; seq=""}}}} END {{print seq}}'
+            cat {input.ref} | awk '{{if ($1 ~ /^[^>]/) {{ seq=seq$1}}; if ($1 ~ /^>/ && NR!=1) {{print seq; seq=""}}}} END {{print seq}}' | tr ACGTacgt TGCAtgca | rev
+        ) >{output}
         """
 
 
@@ -45,12 +45,12 @@ Map the reads to the reference and sort using exact match.
         export LC_ALL=C # speed up sort
 
         awk -v "OFS=\\t" 'NR==FNR {{a[$2] = $1; next}} {{if ($3 in a) print $2,a[$3],"{params.sequence_length}M"; else print $2,"other","NA"}}' \
-        <(
-            cat {input.reference} | awk -v "OFS=\\t" '{{print $1,substr($2, {params.alignment_start},{params.sequence_length})}}'
-        ) \
-        <(
-            zcat {input.reads} | awk 'NR%4==2 || NR%4==1' | paste - -
-        ) | \
-        sed 's/,YI:Z[^\\t]*//g' | sed 's/XI:Z://g' | \
-        sort -k1,1 -k2,2 -k3,3 -S 7G > {output} 2> {log}
+            <(
+                cat {input.reference} | awk -v "OFS=\\t" '{{print $1,substr($2, {params.alignment_start},{params.sequence_length})}}'
+            ) \
+            <(
+                zcat {input.reads} | awk 'NR%4==2 || NR%4==1' | paste - -
+            ) \
+            | sed 's/,YI:Z[^\\t]*//g' | sed 's/XI:Z://g' \
+            | sort -k1,1 -k2,2 -k3,3 -S 7G >{output} 2>{log}
         """

--- a/workflow/rules/assignment/mapping_pbmm2.smk
+++ b/workflow/rules/assignment/mapping_pbmm2.smk
@@ -13,7 +13,7 @@ Create pbmm2 index from design reference.
         getCondaEnv("pbmm2_pysam.yaml")
     shell:
         """
-        pbmm2 index {input.ref} {output} &> {log}
+        pbmm2 index {input.ref} {output} &>{log}
         """
 
 
@@ -41,7 +41,7 @@ Align long reads (BAM or FASTA) to reference using pbmm2.
             --sort \
             --best-n 1 \
             --min-concordance-perc {params.min_concordance} \
-            -j {threads} &> {log}
+            -j {threads} &>{log}
         """
 
 
@@ -69,6 +69,6 @@ barcode TSV for downstream collection and filtering.
             --bam {input.bam} \
             --pattern {params.pattern} \
             --bc-length {params.bc_length} \
-            --output /dev/stdout 2> {log} | \
-        sort -k1,1 -k2,2 -k3,3 -S 7G > {output}
+            --output /dev/stdout 2>{log} \
+            | sort -k1,1 -k2,2 -k3,3 -S 7G >{output}
         """

--- a/workflow/rules/assignment/preprocessing.smk
+++ b/workflow/rules/assignment/preprocessing.smk
@@ -19,5 +19,5 @@ Uses cutadapt to trim adapters based on the primer direction.
     shell:
         """
         cutadapt --cores {threads} {params.adapters} \
-        -o {output.trimmed_reads} <(zcat {input.reads}) &> {log}
+            -o {output.trimmed_reads} <(zcat {input.reads}) &>{log}
         """

--- a/workflow/rules/assignment/statistic.smk
+++ b/workflow/rules/assignment/statistic.smk
@@ -18,7 +18,7 @@ Statistic of the total (unfiltered counts).
         getCondaEnv("python3.yaml")
     shell:
         """
-        python {input.script} --input {input.bc} --output >(sed -n '1,3p;'  > {output}) 2> {log}
+        python {input.script} --input {input.bc} --output >(sed -n '1,3p;' >{output}) 2>{log}
         """
 
 
@@ -37,7 +37,7 @@ Statistic of the assigned counts.
         getCondaEnv("python3.yaml")
     shell:
         """
-        python {input.script} --input {input.bc} --output {output} &> {log}
+        python {input.script} --input {input.bc} --output {output} &>{log}
         """
 
 
@@ -57,7 +57,7 @@ Statistic of the filtered assignment.
         getCondaEnv("r.yaml")
     shell:
         """
-        Rscript {input.script} --input {input.bc} --statistic {output.stats} --plot {output.plot} &> {log}
+        Rscript {input.script} --input {input.bc} --statistic {output.stats} --plot {output.plot} &>{log}
         """
 
 
@@ -77,5 +77,5 @@ Quality metrics of the assignment run
         getCondaEnv("mpralib.yaml")
     shell:
         """
-        python {input.script} assignment --assignment {input.assignment} --design {input.design} --output {output} &> {log}
+        python {input.script} assignment --assignment {input.assignment} --design {input.design} --output {output} &>{log}
         """

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -73,22 +73,120 @@ if not config["skip_version_check"]:
 
 
 def modify_config(config):
-    # update sequence length with when adapters are added via strand sensitive is enabled
+    def get_mapper_window_values(tool, mapper_cfg):
+        mapper_start = None
+        mapper_length = None
+
+        if tool in ["bwa", "bwa-additional-filtering"]:
+            alignment_start_cfg = mapper_cfg.get("alignment_start")
+            if isinstance(alignment_start_cfg, dict):
+                mapper_start = alignment_start_cfg.get("min")
+            elif isinstance(alignment_start_cfg, int):
+                mapper_start = alignment_start_cfg
+
+            sequence_length_cfg = mapper_cfg.get("sequence_length")
+            if isinstance(sequence_length_cfg, dict):
+                mapper_length = sequence_length_cfg.get("min")
+            elif isinstance(sequence_length_cfg, int):
+                mapper_length = sequence_length_cfg
+        else:
+            alignment_start_cfg = mapper_cfg.get("alignment_start")
+            sequence_length_cfg = mapper_cfg.get("sequence_length")
+            if isinstance(alignment_start_cfg, int):
+                mapper_start = alignment_start_cfg
+            if isinstance(sequence_length_cfg, int):
+                mapper_length = sequence_length_cfg
+
+        return mapper_start, mapper_length
+
     if "assignments" in config:
-        for assignment in config["assignments"].keys():
-            if config["assignments"][assignment]["strand_sensitive"]["enable"]:
-                add_length = len(config["assignments"][assignment]["strand_sensitive"]["forward_adapter"]) + len(
-                    config["assignments"][assignment]["strand_sensitive"]["reverse_adapter"]
+        for assignment, assignment_cfg in config["assignments"].items():
+            assignment_cfg.setdefault("design_check", {})
+            assignment_cfg["design_check"].setdefault("fast", True)
+            assignment_cfg["design_check"].setdefault("sequence_collisions", True)
+
+            mapper_tool = assignment_cfg["alignment_tool"]["tool"]
+            mapper_cfg = assignment_cfg["alignment_tool"]["configs"]
+            mapper_start, mapper_length = get_mapper_window_values(mapper_tool, mapper_cfg)
+
+            # For bwa/bwa-additional-filtering/exact, mapper values have precedence if provided.
+            if mapper_tool in ["bwa", "bwa-additional-filtering", "exact"]:
+                if mapper_start is not None:
+                    assignment_cfg["design_check"]["sequence_start"] = mapper_start
+                if mapper_length is not None:
+                    assignment_cfg["design_check"]["sequence_length"] = mapper_length
+            # For other mappers, mapping config must provide both values when collisions are enabled.
+            elif assignment_cfg["design_check"]["sequence_collisions"]:
+                if mapper_start is None or mapper_length is None:
+                    raise ValueError(
+                        "Assignment %s uses mapper '%s' and requires alignment_tool.configs.alignment_start and "
+                        "alignment_tool.configs.sequence_length when design_check.sequence_collisions=true"
+                        % (assignment, mapper_tool)
+                    )
+                assignment_cfg["design_check"]["sequence_start"] = mapper_start
+                assignment_cfg["design_check"]["sequence_length"] = mapper_length
+
+            # update sequence length with when adapters are added via strand sensitive is enabled
+            if assignment_cfg["strand_sensitive"]["enable"]:
+                add_length = len(assignment_cfg["strand_sensitive"]["forward_adapter"]) + len(
+                    assignment_cfg["strand_sensitive"]["reverse_adapter"]
                 )
-                if config["assignments"][assignment]["alignment_tool"]["tool"] == "bwa":
-                    config["assignments"][assignment]["alignment_tool"]["configs"]["sequence_length"]["min"] += add_length
-                    config["assignments"][assignment]["alignment_tool"]["configs"]["sequence_length"]["max"] += add_length
-                else:
-                    config["assignments"][assignment]["alignment_tool"]["configs"]["sequence_length"] += add_length
+                sequence_length_cfg = mapper_cfg.get("sequence_length")
+                if isinstance(sequence_length_cfg, dict):
+                    if "min" in sequence_length_cfg:
+                        sequence_length_cfg["min"] += add_length
+                    if "max" in sequence_length_cfg:
+                        sequence_length_cfg["max"] += add_length
+                elif isinstance(sequence_length_cfg, int):
+                    mapper_cfg["sequence_length"] += add_length
+
+                if isinstance(assignment_cfg["design_check"].get("sequence_length"), int):
+                    assignment_cfg["design_check"]["sequence_length"] += add_length
+
+            # Final runtime validation: only required when sequence collision checking is enabled.
+            if assignment_cfg["design_check"]["sequence_collisions"]:
+                if (
+                    assignment_cfg["design_check"].get("sequence_start") is None
+                    or assignment_cfg["design_check"].get("sequence_length") is None
+                ):
+                    raise ValueError(
+                        "Assignment %s is missing sequence_start/sequence_length for design_check with "
+                        "sequence_collisions=true. Set design_check.sequence_start and design_check.sequence_length "
+                        "or provide mapper-specific values." % assignment
+                    )
+
     return config
 
 
 config = modify_config(config)
+
+
+def getDesignCheckConfig(assignment):
+    return config["assignments"][assignment].get("design_check", {})
+
+
+def getDesignCheckSequenceCollisions(assignment):
+    return getDesignCheckConfig(assignment).get("sequence_collisions", True)
+
+
+def getDesignCheckFast(assignment):
+    return getDesignCheckConfig(assignment).get("fast", True)
+
+
+def getDesignCheckWindowArgs(assignment):
+    if not getDesignCheckSequenceCollisions(assignment):
+        return ""
+
+    start = getDesignCheckConfig(assignment).get("sequence_start")
+    length = getDesignCheckConfig(assignment).get("sequence_length")
+    if start is None or length is None:
+        raise ValueError(
+            "Assignment %s has sequence_collisions=true but no sequence_start/sequence_length in finalized design_check."
+            % assignment
+        )
+    return f"--start {start} --length {length}"
+
+
 ################################
 #### HELPERS AND EXCEPTIONS ####
 ################################

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -19,6 +19,64 @@ def getCondaEnv(name):
 
 
 ##### load config and sample sheets #####
+
+
+# modify config based on certain rules before evaluation
+def modify_config_before_eval(config):
+    def get_mapper_window_values(tool, mapper_cfg):
+        mapper_start = None
+        mapper_length = None
+
+        if tool in ["bwa", "bwa-additional-filtering"]:
+            alignment_start_cfg = mapper_cfg.get("alignment_start")
+            if isinstance(alignment_start_cfg, dict):
+                mapper_start = alignment_start_cfg.get("min")
+            elif isinstance(alignment_start_cfg, int):
+                mapper_start = alignment_start_cfg
+
+            sequence_length_cfg = mapper_cfg.get("sequence_length")
+            if isinstance(sequence_length_cfg, dict):
+                mapper_length = sequence_length_cfg.get("min")
+            elif isinstance(sequence_length_cfg, int):
+                mapper_length = sequence_length_cfg
+        else:
+            alignment_start_cfg = mapper_cfg.get("alignment_start")
+            sequence_length_cfg = mapper_cfg.get("sequence_length")
+            if isinstance(alignment_start_cfg, int):
+                mapper_start = alignment_start_cfg
+            if isinstance(sequence_length_cfg, int):
+                mapper_length = sequence_length_cfg
+
+        return mapper_start, mapper_length
+
+    if "assignments" in config:
+        for assignment, assignment_cfg in config["assignments"].items():
+
+            # Update design check sequence_lenth and seqreunce_start based on alignment tool configs
+            assignment_cfg.setdefault("design_check", {})
+
+            assignment_cfg.setdefault("alignment_tool", {})
+            assignment_cfg["alignment_tool"].setdefault("configs", {})
+
+            mapper_cfg = assignment_cfg["alignment_tool"]["configs"]
+
+            alignment_start_cfg = mapper_cfg.get("alignment_start")
+            if isinstance(alignment_start_cfg, dict):
+                assignment_cfg["design_check"].setdefault("sequence_start", alignment_start_cfg.get("min"))
+            elif isinstance(alignment_start_cfg, int):
+                assignment_cfg["design_check"]["sequence_start"] = alignment_start_cfg
+
+            sequence_length_cfg = mapper_cfg.get("sequence_length")
+            if isinstance(sequence_length_cfg, dict):
+                assignment_cfg["design_check"].setdefault("sequence_length", sequence_length_cfg.get("min"))
+            elif isinstance(sequence_length_cfg, int):
+                assignment_cfg["design_check"]["sequence_length"] = sequence_length_cfg
+
+    return config
+
+
+config = modify_config_before_eval(config)
+
 from snakemake.utils import validate
 import pandas as pd
 
@@ -69,63 +127,10 @@ if not config["skip_version_check"]:
     check_version(version.parse(config["version"]))
 
 
-# modify config based on certain rules
-
-
-def modify_config(config):
-    def get_mapper_window_values(tool, mapper_cfg):
-        mapper_start = None
-        mapper_length = None
-
-        if tool in ["bwa", "bwa-additional-filtering"]:
-            alignment_start_cfg = mapper_cfg.get("alignment_start")
-            if isinstance(alignment_start_cfg, dict):
-                mapper_start = alignment_start_cfg.get("min")
-            elif isinstance(alignment_start_cfg, int):
-                mapper_start = alignment_start_cfg
-
-            sequence_length_cfg = mapper_cfg.get("sequence_length")
-            if isinstance(sequence_length_cfg, dict):
-                mapper_length = sequence_length_cfg.get("min")
-            elif isinstance(sequence_length_cfg, int):
-                mapper_length = sequence_length_cfg
-        else:
-            alignment_start_cfg = mapper_cfg.get("alignment_start")
-            sequence_length_cfg = mapper_cfg.get("sequence_length")
-            if isinstance(alignment_start_cfg, int):
-                mapper_start = alignment_start_cfg
-            if isinstance(sequence_length_cfg, int):
-                mapper_length = sequence_length_cfg
-
-        return mapper_start, mapper_length
-
+# modify config based on certain rules after evaluation
+def modify_config_after_eval(config):
     if "assignments" in config:
         for assignment, assignment_cfg in config["assignments"].items():
-            assignment_cfg.setdefault("design_check", {})
-            assignment_cfg["design_check"].setdefault("fast", True)
-            assignment_cfg["design_check"].setdefault("sequence_collisions", True)
-
-            mapper_tool = assignment_cfg["alignment_tool"]["tool"]
-            mapper_cfg = assignment_cfg["alignment_tool"]["configs"]
-            mapper_start, mapper_length = get_mapper_window_values(mapper_tool, mapper_cfg)
-
-            # For bwa/bwa-additional-filtering/exact, mapper values have precedence if provided.
-            if mapper_tool in ["bwa", "bwa-additional-filtering", "exact"]:
-                if mapper_start is not None:
-                    assignment_cfg["design_check"]["sequence_start"] = mapper_start
-                if mapper_length is not None:
-                    assignment_cfg["design_check"]["sequence_length"] = mapper_length
-            # For other mappers, mapping config must provide both values when collisions are enabled.
-            elif assignment_cfg["design_check"]["sequence_collisions"]:
-                if mapper_start is None or mapper_length is None:
-                    raise ValueError(
-                        "Assignment %s uses mapper '%s' and requires alignment_tool.configs.alignment_start and "
-                        "alignment_tool.configs.sequence_length when design_check.sequence_collisions=true"
-                        % (assignment, mapper_tool)
-                    )
-                assignment_cfg["design_check"]["sequence_start"] = mapper_start
-                assignment_cfg["design_check"]["sequence_length"] = mapper_length
-
             # update sequence length with when adapters are added via strand sensitive is enabled
             if assignment_cfg["strand_sensitive"]["enable"]:
                 add_length = len(assignment_cfg["strand_sensitive"]["forward_adapter"]) + len(
@@ -143,48 +148,10 @@ def modify_config(config):
                 if isinstance(assignment_cfg["design_check"].get("sequence_length"), int):
                     assignment_cfg["design_check"]["sequence_length"] += add_length
 
-            # Final runtime validation: only required when sequence collision checking is enabled.
-            if assignment_cfg["design_check"]["sequence_collisions"]:
-                if (
-                    assignment_cfg["design_check"].get("sequence_start") is None
-                    or assignment_cfg["design_check"].get("sequence_length") is None
-                ):
-                    raise ValueError(
-                        "Assignment %s is missing sequence_start/sequence_length for design_check with "
-                        "sequence_collisions=true. Set design_check.sequence_start and design_check.sequence_length "
-                        "or provide mapper-specific values." % assignment
-                    )
-
     return config
 
 
-config = modify_config(config)
-
-
-def getDesignCheckConfig(assignment):
-    return config["assignments"][assignment].get("design_check", {})
-
-
-def getDesignCheckSequenceCollisions(assignment):
-    return getDesignCheckConfig(assignment).get("sequence_collisions", True)
-
-
-def getDesignCheckFast(assignment):
-    return getDesignCheckConfig(assignment).get("fast", True)
-
-
-def getDesignCheckWindowArgs(assignment):
-    if not getDesignCheckSequenceCollisions(assignment):
-        return ""
-
-    start = getDesignCheckConfig(assignment).get("sequence_start")
-    length = getDesignCheckConfig(assignment).get("sequence_length")
-    if start is None or length is None:
-        raise ValueError(
-            "Assignment %s has sequence_collisions=true but no sequence_start/sequence_length in finalized design_check."
-            % assignment
-        )
-    return f"--start {start} --length {length}"
+config = modify_config_after_eval(config)
 
 
 ################################

--- a/workflow/rules/experiment/assigned_counts.smk
+++ b/workflow/rules/experiment/assigned_counts.smk
@@ -23,11 +23,11 @@ Use only unique assignments and do sampling if needed.
     shell:
         """
         python {input.script} \
-        --input {input.assignment} \
-        {params.samplingprop} \
-        {params.samplingtotal} \
-        {params.seed} \
-        --output {output} &> {log}
+            --input {input.assignment} \
+            {params.samplingprop} \
+            {params.samplingtotal} \
+            {params.seed} \
+            --output {output} &>{log}
         """
 
 
@@ -43,7 +43,7 @@ rule experiment_assigned_counts_createAssignmentPickleFile:
         getCondaEnv("python3.yaml")
     shell:
         """
-        python {input.script} -i {input.files} -o {output} &> {log}
+        python {input.script} -i {input.files} -o {output} &>{log}
         """
 
 
@@ -71,10 +71,10 @@ Assign RNA and DNA barcodes seperately to make the statistic for assigned
     shell:
         """
         python {input.script} --counts {input.counts} \
-        --assignment {input.association} \
-        --output {output.counts} \
-        --statistic {output.statistic} \
-        --name {params.name} &> {log}
+            --assignment {input.association} \
+            --output {output.counts} \
+            --statistic {output.statistic} \
+            --name {params.name} &>{log}
         """
 
 
@@ -113,13 +113,13 @@ Assign merged RNA/DNA barcodes. Filter BC depending on the min_counts option.
     shell:
         """
         python {input.script} --counts {input.counts} \
-        --minRNACounts {params.minRNACounts} --minDNACounts {params.minDNACounts} \
-        --assignment {input.association} \
-        {params.outlier_detection} --outlier-barcodes {output.removed_bcs} \
-        {params.outlier_zscore_times} \
-        --output {output.counts} \
-        --bcOutput {output.bc_counts} \
-        --statistic {output.statistic} &> {log}
+            --minRNACounts {params.minRNACounts} --minDNACounts {params.minDNACounts} \
+            --assignment {input.association} \
+            {params.outlier_detection} --outlier-barcodes {output.removed_bcs} \
+            {params.outlier_zscore_times} \
+            --output {output.counts} \
+            --bcOutput {output.bc_counts} \
+            --statistic {output.statistic} &>{log}
         """
 
 
@@ -157,12 +157,12 @@ Final master table with all replicates combined. With and without threshold.
     shell:
         """
         Rscript {input.script} \
-        --threshold {params.thresh} \
-        --files {params.files} \
-        --replicates {params.replicates} \
-        --output {output.thresh} \
-        --output-all {output.all} \
-        --statistic {output.statistic} &> {log}
+            --threshold {params.thresh} \
+            --files {params.files} \
+            --replicates {params.replicates} \
+            --output {output.thresh} \
+            --output-all {output.all} \
+            --statistic {output.statistic} &>{log}
         """
 
 
@@ -201,10 +201,10 @@ Combine replictes of assigned barcode counts into one file.
     shell:
         """
         python {input.script} \
-        {params.bc_counts} \
-        --threshold {params.thresh} \
-        --output-threshold {output.bc_merged_thresh} \
-        --output {output.bc_merged_all} &> {log}
+            {params.bc_counts} \
+            --threshold {params.thresh} \
+            --output-threshold {output.bc_merged_thresh} \
+            --output {output.bc_merged_all} &>{log}
         """
 
 
@@ -232,9 +232,9 @@ Combine replicates of master table by summing counts up and using also the avera
     shell:
         """
         python {input.script} \
-        --input {input.master_table} \
-        {params.label_file} \
-        --output {output}  &> {log}
+            --input {input.master_table} \
+            {params.label_file} \
+            --output {output} &>{log}
         """
 
 
@@ -254,8 +254,8 @@ Will copy final files to the main folder so that it is clear which files to use.
         getCondaEnv("default.yaml")
     shell:
         """
-        cp {input.all} {output.all} &> {log}
-        cp {input.bc_all} {output.bc_all} &>> {log}
+        cp {input.all} {output.all} &>{log}
+        cp {input.bc_all} {output.bc_all} &>>{log}
         """
 
 
@@ -277,6 +277,6 @@ Will copy final files to the main folder so that it is clear which files to use.
         getCondaEnv("default.yaml")
     shell:
         """
-        cp {input.thresh} {output.thresh} &> {log}
-        cp {input.bc_thresh} {output.bc_thresh} &>> {log}
+        cp {input.thresh} {output.thresh} &>{log}
+        cp {input.bc_thresh} {output.bc_thresh} &>>{log}
         """

--- a/workflow/rules/experiment/counts.smk
+++ b/workflow/rules/experiment/counts.smk
@@ -26,12 +26,12 @@ Filter the counts to BCs only of the correct length (defined in the config file)
         bc_length=lambda wc: config["experiments"][wc.project]["bc_length"],
     shell:
         """
-        bc={params.bc_length};
-        echo $bc;
-        zcat {input} | grep -v "N" | \
-        awk -v var="$bc" -v 'OFS=\\t' '{{ if (length($1) == var) {{ print }} }}' | \
-        sort | \
-        gzip -c > {output}
+        bc={params.bc_length}
+        echo $bc
+        zcat {input} | grep -v "N" \
+            | awk -v var="$bc" -v 'OFS=\\t' '{{ if (length($1) == var) {{ print }} }}' \
+            | sort \
+            | gzip -c >{output}
         """
 
 
@@ -50,10 +50,10 @@ Discarding PCR duplicates (taking BCxUMI only one time)
         getCondaEnv("default.yaml")
     shell:
         """
-        zcat {input} | awk '{{print $1}}' | \
-        uniq -c | \
-        awk -v 'OFS=\\t' '{{ print $2,$1 }}' | \
-        gzip -c > {output.counts} 2> {log}
+        zcat {input} | awk '{{print $1}}' \
+            | uniq -c \
+            | awk -v 'OFS=\\t' '{{ print $2,$1 }}' \
+            | gzip -c >{output.counts} 2>{log}
         """
 
 
@@ -79,12 +79,12 @@ Creates full + new distribution DNA files
     shell:
         """
         python {input.script} --input {input.counts} \
-        {params.samplingprop} \
-        {params.downsampling} \
-        {params.samplingtotal} \
-        {params.seed} \
-        {params.filtermincounts} \
-        --output {output} &> {log}
+            {params.samplingprop} \
+            {params.downsampling} \
+            {params.samplingtotal} \
+            {params.seed} \
+            {params.filtermincounts} \
+            --output {output} &>{log}
         """
 
 
@@ -111,17 +111,16 @@ Second with zeros, so a BC can be defined only in the DNA or RNA (RNA or DNA min
         minDNACounts=lambda wc: counts_getFilterConfig(wc.project, wc.config, "DNA", "min_counts"),
     shell:
         """
-        zero={params.zero};
-        if [[ -z "${{zero//false}}" ]]
-        then
+        zero={params.zero}
+        if [[ -z "${{zero//false}}" ]]; then
             join -1 1 -2 1 -t"$(echo -e '\\t')" \
-            <( zcat  {input.dna} | sort ) \
-            <( zcat {input.rna} | sort);
+                <(zcat {input.dna} | sort) \
+                <(zcat {input.rna} | sort)
         else
             join -e 0 -a1 -a2 -t"$(echo -e '\\t')" -o 0 1.2 2.2 \
-            <( zcat  {input.dna} | sort ) \
-            <( zcat {input.rna}  | sort);
-        fi  | \
-        awk -v 'OFS=\\t' '{{if ($2 >= {params.minDNACounts} && $3 >= {params.minRNACounts}) {{print $0}}}}' | \
-        gzip -c > {output} 2> {log}
+                <(zcat {input.dna} | sort) \
+                <(zcat {input.rna} | sort)
+        fi \
+            | awk -v 'OFS=\\t' '{{if ($2 >= {params.minDNACounts} && $3 >= {params.minRNACounts}) {{print $0}}}}' \
+            | gzip -c >{output} 2>{log}
         """

--- a/workflow/rules/experiment/counts/counts_demultiplex.smk
+++ b/workflow/rules/experiment/counts/counts_demultiplex.smk
@@ -21,8 +21,8 @@ Create the demultiplexing index file for the experiment.
     shell:
         """
         python {input.script} \
-        --experiment {input.experiment_file} \
-        --output {output} &> {log}
+            --experiment {input.experiment_file} \
+            --output {output} &>{log}
         """
 
 
@@ -47,28 +47,28 @@ Demultiplexing the data and create demultiplexed bam files per condition.
         outdir=lambda w, output: os.path.split(output[0])[0],
     shell:
         """
-            set +o pipefail;
+        set +o pipefail
 
-            umi_length=`zcat {input.umi_fastq} | head -2 | tail -1 | wc -c`;
-            umi_length=$(expr $(($umi_length-1)));
+        umi_length=$(zcat {input.umi_fastq} | head -2 | tail -1 | wc -c)
+        umi_length=$(expr $(($umi_length - 1)))
 
-            idx_length=`zcat {input.index_fastq} | head -2 | tail -1 | wc -c`;
-            idx_length=$(expr $(($idx_length-1)));
+        idx_length=$(zcat {input.index_fastq} | head -2 | tail -1 | wc -c)
+        idx_length=$(expr $(($idx_length - 1)))
 
-            fwd_length=`zcat {input.fwd_fastq} | head -2 | tail -1 | wc -c`;
-            fwd_length=$(expr $(($fwd_length-1)));
+        fwd_length=$(zcat {input.fwd_fastq} | head -2 | tail -1 | wc -c)
+        fwd_length=$(expr $(($fwd_length - 1)))
 
-            rev_start=$(expr $(($fwd_length+$idx_length+1)));
+        rev_start=$(expr $(($fwd_length + $idx_length + 1)))
 
-            echo $rev_start
-            echo $idx_length
-            echo $umi_length
+        echo $rev_start
+        echo $idx_length
+        echo $umi_length
 
-            python {input.script} -s $rev_start -l $idx_length -m $umi_length -i {input.index_list} --outdir {params.outdir} --remove --summary --separate_files \
-            <(\
-        paste <( zcat {input.fwd_fastq} ) <( zcat {input.index_fastq} ) <( zcat {input.rev_fastq} ) <( zcat {input.umi_fastq} ) | \
-            awk '{{ count+=1; if ((count == 1) || (count == 3)) {{ print $1 }} else {{ print $1$2$3$4 }}; if (count == 4) {{ count=0 }} }}'\
-            ) &> {log}
+        python {input.script} -s $rev_start -l $idx_length -m $umi_length -i {input.index_list} --outdir {params.outdir} --remove --summary --separate_files \
+            <(
+                paste <(zcat {input.fwd_fastq}) <(zcat {input.index_fastq}) <(zcat {input.rev_fastq}) <(zcat {input.umi_fastq}) \
+                    | awk '{{ count+=1; if ((count == 1) || (count == 3)) {{ print $1 }} else {{ print $1$2$3$4 }}; if (count == 4) {{ count=0 }} }}'
+            ) &>{log}
         """
 
 
@@ -99,7 +99,7 @@ Merge and trim reads in demultiplexed bam files.
         bam="results/experiments/{project}/counts/demultiplex.{condition}.{replicate}.{type}.bam",
     shell:
         """
-        samtools view -h {params.bam} | \
-        python {input.script} -p --mergeoverlap -f ACCGGTCGCCACCATGGTGAGCAAGGGCGAGGA -s CTTAGCTTTCGCTTAGCGATGTGTTCACTTTGC \
-        > {output} 2> {log}
+        samtools view -h {params.bam} \
+            | python {input.script} -p --mergeoverlap -f ACCGGTCGCCACCATGGTGAGCAAGGGCGAGGA -s CTTAGCTTTCGCTTAGCGATGTGTTCACTTTGC \
+                >{output} 2>{log}
         """

--- a/workflow/rules/experiment/counts/counts_noUMI.smk
+++ b/workflow/rules/experiment/counts/counts_noUMI.smk
@@ -28,23 +28,23 @@ Create a BAM file from FASTQ input, merge FWD and REV read and save UMI in XI fl
         datasetID="{condition}.{replicate}.{type}",
     shell:
         """
-        set +o pipefail;
+        set +o pipefail
 
-        fwd_length=`zcat {input.fwd_fastq} | head -2 | tail -1 | wc -c`;
-        fwd_length=$(expr $(($fwd_length-1)));
+        fwd_length=$(zcat {input.fwd_fastq} | head -2 | tail -1 | wc -c)
+        fwd_length=$(expr $(($fwd_length - 1)))
 
-        rev_start=$(expr $(($fwd_length+1)));
+        rev_start=$(expr $(($fwd_length + 1)))
 
-        minoverlap=`echo ${{fwd_length}} ${{fwd_length}} {params.bc_length} | awk '{{print ($1+$2-$3-1 < 11) ? $1+$2-$3-1 : 11}}'`;
+        minoverlap=$(echo ${{fwd_length}} ${{fwd_length}} {params.bc_length} | awk '{{print ($1+$2-$3-1 < 11) ? $1+$2-$3-1 : 11}}')
 
-        paste <( zcat {input.fwd_fastq} ) <( zcat {input.rev_fastq}  ) | \
-        awk '{{if (NR % 4 == 2 || NR % 4 == 0) {{
-                print $1$2
-            }} else {{
-                print $1
-            }}}}' | \
-        python {input.script_FastQ2doubleIndexBAM} -p -s $rev_start -l 0 -m 0 --RG {params.datasetID} | \
-        python {input.script_MergeTrimReadsBAM} --FirstReadChimeraFilter '' --adapterFirstRead '' --adapterSecondRead '' -p --mergeoverlap --minoverlap $minoverlap > {output} 2> {log}
+        paste <(zcat {input.fwd_fastq}) <(zcat {input.rev_fastq}) \
+            | awk '{{if (NR % 4 == 2 || NR % 4 == 0) {{
+                                                        print $1$2
+                                                    }} else {{
+                                                        print $1
+                                                    }}}}' \
+            | python {input.script_FastQ2doubleIndexBAM} -p -s $rev_start -l 0 -m 0 --RG {params.datasetID} \
+            | python {input.script_MergeTrimReadsBAM} --FirstReadChimeraFilter '' --adapterFirstRead '' --adapterSecondRead '' -p --mergeoverlap --minoverlap $minoverlap >{output} 2>{log}
         """
 
 
@@ -70,8 +70,8 @@ Counting BCsxUMIs from the BAM files.
         datasetID="{condition}.{replicate}.{type}",
     shell:
         """
-        samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
-        awk -v 'OFS=\\t' '{{ print $10 }}' | \
-        sort | \
-        gzip -c > {output} 2> {log}
+        samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} \
+            | awk -v 'OFS=\\t' '{{ print $10 }}' \
+            | sort \
+            | gzip -c >{output} 2>{log}
         """

--- a/workflow/rules/experiment/counts/counts_onlyFWD.smk
+++ b/workflow/rules/experiment/counts/counts_onlyFWD.smk
@@ -22,8 +22,8 @@ Getting the BCs from the reads using fixed length.
         bc_extraction=lambda wc: config["experiments"][wc.project].get("bc_extraction", "start"),
     shell:
         """
-        zcat {input} | \
-        awk 'NR%4==2 {{if ("{params.bc_extraction}" == "start") print substr($1,1,{params.bc_length}); else print substr($1,length($1)-{params.bc_length}+1)}}' |\
-        sort | \
-        gzip -c > {output} 2> {log}
+        zcat {input} \
+            | awk 'NR%4==2 {{if ("{params.bc_extraction}" == "start") print substr($1,1,{params.bc_length}); else print substr($1,length($1)-{params.bc_length}+1)}}' \
+            | sort \
+            | gzip -c >{output} 2>{log}
         """

--- a/workflow/rules/experiment/counts/counts_onlyFWDWithUMI.smk
+++ b/workflow/rules/experiment/counts/counts_onlyFWDWithUMI.smk
@@ -33,9 +33,9 @@ Getting the BCs and UMIs from the reads using fixed length.
     shell:
         """
         paste <(zcat {input.fwd_fastq} | awk 'NR%4==2 {{if ("{params.bc_extraction}" == "start") print substr($1,1,{params.bc_length}); else print substr($1,length($1)-{params.bc_length}+1)}}') \
-              <(zcat {input.umi_fastq} | awk 'NR%4==2 {{if ("{params.umi_extraction}" == "start") print substr($1,1,{params.umi_length}); else print substr($1,length($1)-{params.umi_length}+1)}}') | \
-        awk -v 'OFS=\\t' 'length($2) == {params.umi_length} {{print $0}}' | \
-        sort | uniq -c | \
-        awk -v 'OFS=\\t' '{{ print $2,$3,$1 }}' | \
-        gzip -c > {output} 2> {log}
+            <(zcat {input.umi_fastq} | awk 'NR%4==2 {{if ("{params.umi_extraction}" == "start") print substr($1,1,{params.umi_length}); else print substr($1,length($1)-{params.umi_length}+1)}}') \
+            | awk -v 'OFS=\\t' 'length($2) == {params.umi_length} {{print $0}}' \
+            | sort | uniq -c \
+            | awk -v 'OFS=\\t' '{{ print $2,$3,$1 }}' \
+            | gzip -c >{output} 2>{log}
         """

--- a/workflow/rules/experiment/counts/counts_umi.smk
+++ b/workflow/rules/experiment/counts/counts_umi.smk
@@ -30,22 +30,22 @@ Create a BAM file from FASTQ input, merge FWD and REV read and save UMI in XI fl
         datasetID="{condition}.{replicate}.{type}",
     shell:
         """
-        set +o pipefail;
+        set +o pipefail
 
-        fwd_length=`zcat {input.fwd_fastq} | head -2 | tail -1 | wc -c`;
-        fwd_length=$(expr $(($fwd_length-1)));
+        fwd_length=$(zcat {input.fwd_fastq} | head -2 | tail -1 | wc -c)
+        fwd_length=$(expr $(($fwd_length - 1)))
 
-        rev_start=$(expr $(($fwd_length+1)));
+        rev_start=$(expr $(($fwd_length + 1)))
 
-        minoverlap=`echo ${{fwd_length}} ${{fwd_length}} {params.bc_length} | awk '{{print ($1+$2-$3-1 < 11) ? $1+$2-$3-1 : 11}}'`;
+        minoverlap=$(echo ${{fwd_length}} ${{fwd_length}} {params.bc_length} | awk '{{print ($1+$2-$3-1 < 11) ? $1+$2-$3-1 : 11}}')
 
-        echo $rev_start >> {log}
-        echo $minoverlap >> {log}
+        echo $rev_start >>{log}
+        echo $minoverlap >>{log}
 
-        paste <( zcat {input.fwd_fastq} ) <( zcat {input.rev_fastq}  ) <( zcat {input.umi_fastq} ) | \
-        awk '{{if (NR % 4 == 2 || NR % 4 == 0) {{print $1$2$3}} else {{print $1}}}}' | \
-        python {input.script_FastQ2doubleIndexBAM} -p -s $rev_start -l 0 -m {params.umi_length} --RG {params.datasetID} | \
-        python {input.script_MergeTrimReadsBAM} --FirstReadChimeraFilter '' --adapterFirstRead '' --adapterSecondRead '' -p --mergeoverlap --minoverlap $minoverlap > {output} 2>> {log}
+        paste <(zcat {input.fwd_fastq}) <(zcat {input.rev_fastq}) <(zcat {input.umi_fastq}) \
+            | awk '{{if (NR % 4 == 2 || NR % 4 == 0) {{print $1$2$3}} else {{print $1}}}}' \
+            | python {input.script_FastQ2doubleIndexBAM} -p -s $rev_start -l 0 -m {params.umi_length} --RG {params.datasetID} \
+            | python {input.script_MergeTrimReadsBAM} --FirstReadChimeraFilter '' --adapterFirstRead '' --adapterSecondRead '' -p --mergeoverlap --minoverlap $minoverlap >{output} 2>>{log}
         """
 
 
@@ -76,11 +76,11 @@ Counting BCsxUMIs from the BAM files.
         datasetID="{condition}.{replicate}.{type}",
     shell:
         """
-        samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} | \
-        awk -v 'OFS=\\t' '{{ for (i=12; i<=NF; i++) {{
-          if ($i ~ /^XJ:Z:/) print $10,substr($i,6,{params.umi_length})
-        }}}}' | \
-        sort | uniq -c | \
-        awk -v 'OFS=\\t' '{{ print $2,$3,$1 }}' | \
-        gzip -c > {output} 2> {log}
+        samtools merge -c -o - {input} | samtools view -F 1 -r {params.datasetID} \
+            | awk -v 'OFS=\\t' '{{ for (i=12; i<=NF; i++) {{
+                                                  if ($i ~ /^XJ:Z:/) print $10,substr($i,6,{params.umi_length})
+                                                }}}}' \
+            | sort | uniq -c \
+            | awk -v 'OFS=\\t' '{{ print $2,$3,$1 }}' \
+            | gzip -c >{output} 2>{log}
         """

--- a/workflow/rules/experiment/preprocessing.smk
+++ b/workflow/rules/experiment/preprocessing.smk
@@ -27,7 +27,7 @@ n is given by split_read in the configuration file.
         for file in {output}; do
             OUTPUT_FILES="${{OUTPUT_FILES}} -o ${{file}}"
         done
-        fastqsplitter -i <(zcat {input}) -t 1 ${{OUTPUT_FILES}} &> {log}
+        fastqsplitter -i <(zcat {input}) -t 1 ${{OUTPUT_FILES}} &>{log}
         """
 
 
@@ -53,5 +53,5 @@ Getting the BCs from the reads using cutadapt.
     shell:
         """
         cutadapt --cores {threads} {params.adapters} \
-        -o {output.trimmed_reads} <(zcat {input.reads}) &> {log}
+            -o {output.trimmed_reads} <(zcat {input.reads}) &>{log}
         """

--- a/workflow/rules/experiment/statistic.smk
+++ b/workflow/rules/experiment/statistic.smk
@@ -37,7 +37,7 @@ Quality metrics of the assignment run
     shell:
         """
         python {input.script} experiment \
-        --assignment {input.assignment} --barcode {input.barcode} \
-        --bc-threshold {params.bc_threshold} \
-        --output {output} &> {log}
+            --assignment {input.assignment} --barcode {input.barcode} \
+            --bc-threshold {params.bc_threshold} \
+            --output {output} &>{log}
         """

--- a/workflow/rules/experiment/statistic/assigned_counts.smk
+++ b/workflow/rules/experiment/statistic/assigned_counts.smk
@@ -26,13 +26,13 @@ Combine assigned counts statistic per replicate and modality (DNA and RNA not me
         getCondaEnv("default.yaml")
     shell:
         """
-        set +o pipefail;
+        set +o pipefail
         (
-            zcat {input.stats[0]} | head -n 1;
+            zcat {input.stats[0]} | head -n 1
             for i in {input.stats}; do
                 zcat $i | tail -n +2
-            done;
-        ) | gzip -c > {output} 2> {log}
+            done
+        ) | gzip -c >{output} 2>{log}
         """
 
 
@@ -66,13 +66,13 @@ Combined assinged counts statistic per condition (DNA and aRNA not merged)
         getCondaEnv("default.yaml")
     shell:
         """
-        set +o pipefail;
+        set +o pipefail
         (
-            zcat {input.stats[0]} | head -n 1;
+            zcat {input.stats[0]} | head -n 1
             for i in {input.stats}; do
                 zcat $i | tail -n +2
-            done;
-        ) > {output} 2> {log}
+            done
+        ) >{output} 2>{log}
         """
 
 
@@ -108,9 +108,9 @@ Combine assigned counts statistic per replicate (DNA and RNA merged)
     shell:
         """
         python {input.script} \
-        --condition {params.cond} \
-        {params.statistic} \
-        --output {output} &> {log}
+            --condition {params.cond} \
+            {params.statistic} \
+            --output {output} &>{log}
         """
 
 
@@ -144,11 +144,11 @@ Combine assigned counts statistic per condition (DNA and RNA merged)
         getCondaEnv("default.yaml")
     shell:
         """
-        set +o pipefail;
+        set +o pipefail
         (
-            zcat {input.files[0]} | head -n 1;
+            zcat {input.files[0]} | head -n 1
             for i in {input.files}; do
                 zcat $i | tail -n +2
             done
-        ) > {output} 2> {log}
+        ) >{output} 2>{log}
         """

--- a/workflow/rules/experiment/statistic/bc_overlap.smk
+++ b/workflow/rules/experiment/statistic/bc_overlap.smk
@@ -39,9 +39,9 @@ Get overlap of counts and barcodes between replicates.
     shell:
         """
         Rscript {input.script} \
-        --outfile {output} \
-        --condition {params.cond} \
-        --files {params.input} --replicates {params.replicates} &> {log}
+            --outfile {output} \
+            --condition {params.cond} \
+            --files {params.input} --replicates {params.replicates} &>{log}
         """
 
 
@@ -74,13 +74,13 @@ Combine overlap BC and count statistic into one file (raw counts).
         getCondaEnv("default.yaml")
     shell:
         """
-        set +o pipefail;
+        set +o pipefail
         (
-            cat {input.statistic[0]} | head -n 1;
+            cat {input.statistic[0]} | head -n 1
             for i in {input.statistic}; do
                 cat $i | tail -n +2
-            done;
-        ) > {output} 2> {log}
+            done
+        ) >{output} 2>{log}
         """
 
 
@@ -112,11 +112,11 @@ Combine overlap BC and count statistic into one file (assigned counts).
         getCondaEnv("default.yaml")
     shell:
         """
-        set +o pipefail;
+        set +o pipefail
         (
-            cat {input.statistic[0]} | head -n 1;
+            cat {input.statistic[0]} | head -n 1
             for i in {input.statistic}; do
                 cat $i | tail -n +2
-            done;
-        ) > {output} 2> {log}
+            done
+        ) >{output} 2>{log}
         """

--- a/workflow/rules/experiment/statistic/correlation.smk
+++ b/workflow/rules/experiment/statistic/correlation.smk
@@ -61,10 +61,10 @@ Calculate the correlation of the raw counts for each condition across replicates
     shell:
         """
         Rscript {input.script} \
-        --outdir {params.outdir} \
-        --condition {params.cond} \
-        --mindnacounts {params.minDNACounts} --minrnacounts {params.minRNACounts} \
-        --files {params.input} --replicates {params.replicates} &> {log}
+            --outdir {params.outdir} \
+            --condition {params.cond} \
+            --mindnacounts {params.minDNACounts} --minrnacounts {params.minRNACounts} \
+            --files {params.input} --replicates {params.replicates} &>{log}
         """
 
 
@@ -94,10 +94,10 @@ Generate histogram and boxplots of the raw counts for each condition across repl
     shell:
         """
         Rscript {input.script} \
-        --outdir {params.outdir} \
-        --condition {params.cond} \
-        --mindnacounts {params.minDNACounts} --minrnacounts {params.minRNACounts} \
-        --files {params.input} --replicates {params.replicates} &> {log}
+            --outdir {params.outdir} \
+            --condition {params.cond} \
+            --mindnacounts {params.minDNACounts} --minrnacounts {params.minRNACounts} \
+            --files {params.input} --replicates {params.replicates} &>{log}
         """
 
 
@@ -128,11 +128,11 @@ Combine the correlation of the raw counts for each condition across replicates i
     shell:
         """
         (
-        cat {input.files[0]} | head -n 1;
-        for i in {input.files}; do
-            cat $i | tail -n +2;
-        done;
-        ) > {output} 2> {log}
+            cat {input.files[0]} | head -n 1
+            for i in {input.files}; do
+                cat $i | tail -n +2
+            done
+        ) >{output} 2>{log}
         """
 
 
@@ -163,11 +163,11 @@ Combine the correlation of the assigned counts for each condition across replica
     shell:
         """
         (
-        cat {input.files[0]} | head -n 1;
-        for i in {input.files}; do
-            cat $i | tail -n +2;
-        done;
-        ) > {output} 2> {log}
+            cat {input.files[0]} | head -n 1
+            for i in {input.files}; do
+                cat $i | tail -n +2
+            done
+        ) >{output} 2>{log}
         """
 
 
@@ -297,12 +297,12 @@ Calculate the correlation of oligos for each condition across replicates.
     shell:
         """
         Rscript {input.script} \
-        --condition {params.cond} \
-        {params.label} \
-        --files {params.files} \
-        --replicates {params.replicates} \
-        --threshold {params.thresh} \
-        --outdir {params.outdir} &> {log}
+            --condition {params.cond} \
+            {params.label} \
+            --files {params.files} \
+            --replicates {params.replicates} \
+            --threshold {params.thresh} \
+            --outdir {params.outdir} &>{log}
         """
 
 
@@ -356,12 +356,12 @@ Generate histogram and boxplots of the oligos for each condition across replicat
     shell:
         """
         Rscript {input.script} \
-        --condition {params.cond} \
-        {params.label} \
-        --files {params.files} \
-        --replicates {params.replicates} \
-        --threshold {params.thresh} \
-        --outdir {params.outdir} &> {log}
+            --condition {params.cond} \
+            {params.label} \
+            --files {params.files} \
+            --replicates {params.replicates} \
+            --threshold {params.thresh} \
+            --outdir {params.outdir} &>{log}
         """
 
 
@@ -398,14 +398,14 @@ Combine the correlation of oligos for each condition across replicates into one 
         thresh=lambda wc: config["experiments"][wc.project]["configs"][wc.config]["filter"]["bc_threshold"],
     shell:
         """
-        set +o pipefail;
+        set +o pipefail
         (
-        cat {input.correlation[0]} | head -n 1 | awk -v 'OFS=\\t' '{{print $0,"threshold (min {params.thresh})"}}';
-        for i in {input.correlation}; do
-            cat $i | tail -n +2 | awk -v 'OFS=\\t' '{{print $0,"False"}}'
-        done;
-        for i in {input.correlation_thresh}; do
-            cat $i | tail -n +2 | awk -v 'OFS=\\t' '{{print $0,"True"}}'
-        done;
-        ) > {output} 2> {log}
+            cat {input.correlation[0]} | head -n 1 | awk -v 'OFS=\\t' '{{print $0,"threshold (min {params.thresh})"}}'
+            for i in {input.correlation}; do
+                cat $i | tail -n +2 | awk -v 'OFS=\\t' '{{print $0,"False"}}'
+            done
+            for i in {input.correlation_thresh}; do
+                cat $i | tail -n +2 | awk -v 'OFS=\\t' '{{print $0,"True"}}'
+            done
+        ) >{output} 2>{log}
         """

--- a/workflow/rules/experiment/statistic/counts.smk
+++ b/workflow/rules/experiment/statistic/counts.smk
@@ -30,8 +30,8 @@ Count the 10 most frequent UMIs per condition, replicate and DNA/RNA.
         getCondaEnv("default.yaml")
     shell:
         """
-        set +o pipefail;
-        zcat {input} | cut -f 2 | sort | uniq -c | sort -nr | head > {output} 2> {log}
+        set +o pipefail
+        zcat {input} | cut -f 2 | sort | uniq -c | sort -nr | head >{output} 2>{log}
         """
 
 
@@ -69,12 +69,12 @@ Count the nucleotide composition of the barcodes per condition, replicate and DN
         name="{condition}.{replicate}.{type}",
     shell:
         """
-        zcat {input.counts} | awk '{{print $1}}' | gzip -c > {output.bc};
+        zcat {input.counts} | awk '{{print $1}}' | gzip -c >{output.bc}
         python {input.script} \
-        --column 1 \
-        --chunksize 100000 \
-        --input {output.bc} \
-        --output {output.stats} &> {log}
+            --column 1 \
+            --chunksize 100000 \
+            --input {output.bc} \
+            --output {output.stats} &>{log}
         """
 
 
@@ -105,25 +105,25 @@ Count statistic of barcodes and UMIs per condition, replicate and DNA/RNA.
         type="{type}",
     shell:
         """
-        paste <( echo "{params.cond}") <( echo "{params.rep}") <( echo "{params.type}") \
-        <(
-            zcat {input} | \
-            awk -v OFS='\\t' 'BEGIN{{
-                pbar="NA"
-            }}{{
-                count += $NF; umi_sum+=$3; if (pbar != $1) {{ barcodes+=1 }}; pbar=$1
-            }}END{{
-                if (NR > 0) {{
-                    print umi_sum/NR,count,NR,barcodes
-                }} else {{
-                    print 0,0,0,0
-                }}
-            }}'
-        ) \
-        <(
-            zcat {input} | cut -f 2 | sort -u | wc -l
-        ) | \
-        gzip -c > {output} 2> {log}
+        paste <(echo "{params.cond}") <(echo "{params.rep}") <(echo "{params.type}") \
+            <(
+                zcat {input} \
+                    | awk -v OFS='\\t' 'BEGIN{{
+                                                        pbar="NA"
+                                                    }}{{
+                                                        count += $NF; umi_sum+=$3; if (pbar != $1) {{ barcodes+=1 }}; pbar=$1
+                                                    }}END{{
+                                                        if (NR > 0) {{
+                                                            print umi_sum/NR,count,NR,barcodes
+                                                        }} else {{
+                                                            print 0,0,0,0
+                                                        }}
+                                                    }}'
+            ) \
+            <(
+                zcat {input} | cut -f 2 | sort -u | wc -l
+            ) \
+            | gzip -c >{output} 2>{log}
         """
 
 
@@ -141,7 +141,7 @@ Merge the count statistic of all replicates and conditions into one table.
         getCondaEnv("default.yaml")
     shell:
         """
-        zcat {input} | sort -k1,1 -k3,3 -k2,2 > {output} 2> {log}
+        zcat {input} | sort -k1,1 -k3,3 -k2,2 >{output} 2>{log}
         """
 
 
@@ -163,10 +163,10 @@ Count the number of barcodes shared between RNA and DNA per condition and replic
         rep="{replicate}",
     shell:
         """
-        paste <( echo "{params.cond}") <( echo "{params.rep}") \
-        <( join <( zcat {input.dna} | cut -f 1 | sort | uniq ) \
-        <( zcat {input.rna} | cut -f 1 | sort | uniq ) | wc -l ) | \
-        gzip -c > {output} 2> {log}
+        paste <(echo "{params.cond}") <(echo "{params.rep}") \
+            <(join <(zcat {input.dna} | cut -f 1 | sort | uniq) \
+                <(zcat {input.rna} | cut -f 1 | sort | uniq) | wc -l) \
+            | gzip -c >{output} 2>{log}
         """
 
 
@@ -184,7 +184,7 @@ Merge the shared barcodes statistic of all replicates and conditions into one ta
         getCondaEnv("default.yaml")
     shell:
         """
-        zcat {input} | sort -k1,1 -k2,2 > {output} 2> {log}
+        zcat {input} | sort -k1,1 -k2,2 >{output} 2>{log}
         """
 
 
@@ -212,5 +212,5 @@ Combine the final count statistic of all replicates and conditions into one tabl
         getCondaEnv("r.yaml")
     shell:
         """
-        Rscript {input.script} --count {input.counts} --shared {input.shared} --output {output} > {log}
+        Rscript {input.script} --count {input.counts} --shared {input.shared} --output {output} >{log}
         """

--- a/workflow/rules/qc_report.smk
+++ b/workflow/rules/qc_report.smk
@@ -61,25 +61,25 @@ This rule generates the QC report for the assignment.
     shell:
         """
         (
-            cp {input.quarto_script} {output.quarto_file};
-            cd `dirname {output.quarto_file}`;
-            quarto render `basename {output.quarto_file}` --output `basename {output.assi_file}` \
-            -P "assignment:{wildcards.assignment}" \
-            -P "bc_length:{params.bc_length}" \
-            -P "fraction:{params.fraction}" \
-            -P "min_support:{params.min_support}" \
-            -P "fwd:{params.fwd}" \
-            -P "rev:{params.rev}" \
-            -P "bc:{params.bc}" \
-            -P "workdir:{params.workdir}" \
-            -P "design_file:{input.design_file}" \
-            -P "design_file_checked:{input.design_file_checked}" \
-            -P "configs:{wildcards.assignment_config}" \
-            -P "plot_file:{input.plot}" \
-            -P "statistic_filter_file:{input.statistic_filter}" \
-            -P "statistic_all_file:{input.statistic_all}" \
-            -P "qc_metrics_file:{input.qc_metrics}"
-        ) &> {log}
+            cp {input.quarto_script} {output.quarto_file}
+            cd $(dirname {output.quarto_file})
+            quarto render $(basename {output.quarto_file}) --output $(basename {output.assi_file}) \
+                -P "assignment:{wildcards.assignment}" \
+                -P "bc_length:{params.bc_length}" \
+                -P "fraction:{params.fraction}" \
+                -P "min_support:{params.min_support}" \
+                -P "fwd:{params.fwd}" \
+                -P "rev:{params.rev}" \
+                -P "bc:{params.bc}" \
+                -P "workdir:{params.workdir}" \
+                -P "design_file:{input.design_file}" \
+                -P "design_file_checked:{input.design_file_checked}" \
+                -P "configs:{wildcards.assignment_config}" \
+                -P "plot_file:{input.plot}" \
+                -P "statistic_filter_file:{input.statistic_filter}" \
+                -P "statistic_all_file:{input.statistic_all}" \
+                -P "qc_metrics_file:{input.qc_metrics}"
+        ) &>{log}
         """
 
 
@@ -123,30 +123,30 @@ This rule generates the QC report for the count data.
     shell:
         """
         (
-            cp {input.quarto_script} {output.quarto_file};
-            cd `dirname {output.quarto_file}`;
-            quarto render `basename {output.quarto_file}` --output `basename {output.count_file}` \
-            -P "assignment:{wildcards.assignment}" \
-            -P "project:{wildcards.project}" \
-            -P "dna_over_rna_plot:{input.dna_over_rna}" \
-            -P "dna_over_rna_thresh_plot:{input.dna_over_rna_thresh}" \
-            -P "dna_oligo_coor_min_thre_plot:{input.dna_oligo_coor_min_thre_plot}" \
-            -P "rna_oligo_coor_min_thre_plot:{input.rna_oligo_coor_min_thre_plot}" \
-            -P "dna_oligo_coor_plot:{input.dna_oligo_coor_plot}" \
-            -P "rna_oligo_coor_plot:{input.rna_oligo_coor_plot}" \
-            -P "ratio_oligo_coor_plot:{input.ratio_oligo_coor_plot}" \
-            -P "ratio_oligo_min_thre_plot:{input.ratio_oligo_min_thre_plot}" \
-            -P "statistics_all_merged:{input.statistics_all_merged}" \
-            -P "counts_per_oligo:{input.counts_per_oligo}" \
-            -P "counts_per_bc_dna:{input.counts_per_bc_dna}" \
-            -P "counts_per_bc_rna:{input.counts_per_bc_rna}" \
-            -P "statistics_all_single:{input.statistics_all_single}" \
-            -P "activity_all:{input.activity_all}" \
-            -P "activity_thresh:{input.activity_thresh}" \
-            -P "statistics_all_oligo_cor_all:{input.statistics_all_oligo_cor_all}" \
-            -P "statistics_all_oligo_cor_thresh:{input.statistics_all_oligo_cor_thresh}" \
-            -P "thresh:{params.thresh}" \
-            -P "qc_metrics_file:{input.qc_metrics}" \
-            -P "workdir:{params.workdir}"
-        ) &> {log}
+            cp {input.quarto_script} {output.quarto_file}
+            cd $(dirname {output.quarto_file})
+            quarto render $(basename {output.quarto_file}) --output $(basename {output.count_file}) \
+                -P "assignment:{wildcards.assignment}" \
+                -P "project:{wildcards.project}" \
+                -P "dna_over_rna_plot:{input.dna_over_rna}" \
+                -P "dna_over_rna_thresh_plot:{input.dna_over_rna_thresh}" \
+                -P "dna_oligo_coor_min_thre_plot:{input.dna_oligo_coor_min_thre_plot}" \
+                -P "rna_oligo_coor_min_thre_plot:{input.rna_oligo_coor_min_thre_plot}" \
+                -P "dna_oligo_coor_plot:{input.dna_oligo_coor_plot}" \
+                -P "rna_oligo_coor_plot:{input.rna_oligo_coor_plot}" \
+                -P "ratio_oligo_coor_plot:{input.ratio_oligo_coor_plot}" \
+                -P "ratio_oligo_min_thre_plot:{input.ratio_oligo_min_thre_plot}" \
+                -P "statistics_all_merged:{input.statistics_all_merged}" \
+                -P "counts_per_oligo:{input.counts_per_oligo}" \
+                -P "counts_per_bc_dna:{input.counts_per_bc_dna}" \
+                -P "counts_per_bc_rna:{input.counts_per_bc_rna}" \
+                -P "statistics_all_single:{input.statistics_all_single}" \
+                -P "activity_all:{input.activity_all}" \
+                -P "activity_thresh:{input.activity_thresh}" \
+                -P "statistics_all_oligo_cor_all:{input.statistics_all_oligo_cor_all}" \
+                -P "statistics_all_oligo_cor_thresh:{input.statistics_all_oligo_cor_thresh}" \
+                -P "thresh:{params.thresh}" \
+                -P "qc_metrics_file:{input.qc_metrics}" \
+                -P "workdir:{params.workdir}"
+        ) &>{log}
         """

--- a/workflow/rules/variants.smk
+++ b/workflow/rules/variants.smk
@@ -15,9 +15,9 @@ rule variants_generateVariantTable:
     shell:
         """
         python {input.script} \
-        --counts {input.counts} \
-        --declaration {input.variant_definition} \
-        --output {output} &> {log}
+            --counts {input.counts} \
+            --declaration {input.variant_definition} \
+            --output {output} &>{log}
         """
 
 
@@ -53,10 +53,10 @@ rule variants_MasterTable:
     shell:
         """
         python {input.script} \
-        {params.input} \
-        --minRNACounts {params.minRNACounts} \
-        --minDNACounts {params.minDNACounts} \
-        --output {output} &> {log}
+            {params.input} \
+            --minRNACounts {params.minRNACounts} \
+            --minDNACounts {params.minDNACounts} \
+            --output {output} &>{log}
         """
 
 
@@ -91,10 +91,10 @@ rule variants_correlate:
     shell:
         """
         python {input.script} \
-        --condition {params.cond} \
-        {params.tables} \
-        --bc-threshold {params.threshold} \
-        --output {output} &> {log}
+            --condition {params.cond} \
+            {params.tables} \
+            --bc-threshold {params.threshold} \
+            --output {output} &>{log}
         """
 
 
@@ -123,11 +123,11 @@ rule variants_combineVariantCorrelationTables:
         getCondaEnv("default.yaml")
     shell:
         """
-        set +o pipefail;
+        set +o pipefail
         (
-        zcat {input.correlation[0]} | head -n 1;
-        for i in {input.correlation}; do
-            zcat $i | tail -n +2;
-        done;
-        ) > {output} 2> {log}
+            zcat {input.correlation[0]} | head -n 1
+            for i in {input.correlation}; do
+                zcat $i | tail -n +2
+            done
+        ) >{output} 2>{log}
         """

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -362,6 +362,17 @@ properties:
             required:
               - fast
               - sequence_collisions
+            allOf:
+              - if:
+                  properties:
+                    sequence_collisions:
+                      const: true
+                  required:
+                    - sequence_collisions
+                then:
+                  required:
+                    - sequence_start
+                    - sequence_length
           strand_sensitive:
             type: object
             default: {}

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -64,9 +64,6 @@ properties:
                               type: integer
                             max:
                               type: integer
-                          required:
-                            - min
-                            - max
                         alignment_start:
                           type: object
                           properties:
@@ -74,9 +71,6 @@ properties:
                               type: integer
                             max:
                               type: integer
-                          required:
-                            - min
-                            - max
                         M:
                           type: boolean
                           description: mark shorter split hits as secondary
@@ -93,8 +87,6 @@ properties:
                           type: string
                           description: Optional regex for full CIGAR matching (e.g. 200M or 200M|210M)
                       required:
-                        - sequence_length
-                        - alignment_start
                         - min_mapping_quality
                   required:
                     - configs
@@ -108,25 +100,8 @@ properties:
                       type: object
                       properties:
                         sequence_length:
-                          type: object
-                          properties:
-                            min:
-                              type: integer
-                            max:
-                              type: integer
-                          required:
-                            - min
-                            - max
-                        alignment_start:
-                          type: object
-                          properties:
-                            min:
-                              type: integer
-                            max:
-                              type: integer
-                          required:
-                            - min
-                            - max
+                          type: integer
+                          minimum: 1
                         min_mapping_quality:
                           type: integer
                           minimum: 0
@@ -157,7 +132,6 @@ properties:
                           default: false
                       required:
                         - sequence_length
-                        - alignment_start
                         - min_mapping_quality
                   required:
                     - configs
@@ -174,19 +148,11 @@ properties:
                           type: integer
                           minimum: 0
                           default: 30
-                        sequence_length:
-                          type: integer
-                          minimum: 1
-                        alignment_start:
-                          type: integer
-                          minimum: 1
                         cigar_filter_regex:
                           type: string
                           description: Optional regex for full CIGAR matching (e.g. 200M or 200M|210M)
                       required:
                         - min_mapping_quality
-                        - sequence_length
-                        - alignment_start
                   required:
                     - configs
               - if:
@@ -218,12 +184,6 @@ properties:
                     configs:
                       type: object
                       properties:
-                        alignment_start:
-                          type: integer
-                          minimum: 1
-                        sequence_length:
-                          type: integer
-                          minimum: 1
                         preset:
                           type: string
                           enum:
@@ -239,8 +199,6 @@ properties:
                           maximum: 1
                           default: 0.9
                       required:
-                        - alignment_start
-                        - sequence_length
                         - preset
                         - min_concordance
                   required:
@@ -394,6 +352,12 @@ properties:
               sequence_collisions:
                 type: boolean
                 default: true
+              sequence_start:
+                type: integer
+                minimum: 1
+              sequence_length:
+                type: integer
+                minimum: 1
             default: {}
             required:
               - fast

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -89,6 +89,9 @@ properties:
                           minItems: 1
                           maxItems: 2
                           default: [80]
+                        cigar_filter_regex:
+                          type: string
+                          description: Optional regex for full CIGAR matching (e.g. 200M or 200M|210M)
                       required:
                         - sequence_length
                         - alignment_start
@@ -177,6 +180,9 @@ properties:
                         alignment_start:
                           type: integer
                           minimum: 1
+                        cigar_filter_regex:
+                          type: string
+                          description: Optional regex for full CIGAR matching (e.g. 200M or 200M|210M)
                       required:
                         - min_mapping_quality
                         - sequence_length

--- a/workflow/scripts/assignment/check_design_file.py
+++ b/workflow/scripts/assignment/check_design_file.py
@@ -26,16 +26,18 @@ import pyfastx
 @click.option(
     "--start",
     "start",
-    required=True,
+    required=False,
+    default=None,
     type=int,
     help="Start of the sequence to look at (1 based).",
 )
 @click.option(
     "--length",
     "length",
-    required=True,
+    required=False,
+    default=None,
     type=int,
-    help="length of the sequence to lok at,",
+    help="Length of the sequence to look at.",
 )
 @click.option(
     "--fast-dict/--slow-string-search",
@@ -62,9 +64,12 @@ import pyfastx
     "output",
     required=True,
     type=click.Path(writable=True),
-    help="Output reference fasqt file with attached sequences (if set). Otherwise just a copy.",
+    help="Output reference fasta file with attached sequences (if set). Otherwise just a copy.",
 )
 def cli(input_file, start, length, fast_search, sequence_check, attach_sequence, output):
+
+    if sequence_check != "skip" and (start is None or length is None):
+        raise click.UsageError("--start and --length are required unless --sequence-check is set to skip.")
 
     seq_dict = dict()
 


### PR DESCRIPTION
design check sequence collitions needs now start and length. if set with the config af the mapper tool it can use this value.

Also no sequence_length sand alignment start for bbmap is needed anymore.